### PR TITLE
README.md: Remove mention of sentry nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requirements for prospective validators:
  - 50 KSM.
  - Signed up on the [form][form] and has received approval.
  - Connection to the private telemetry.
- - Seven days of online sentry and validator infrastructure.
+ - Seven days of online validator infrastructure.
 
 Please see the [blog post][thousand] for more information and requirements for
 entering the program.


### PR DESCRIPTION
Sentry nodes have been deprecated (see https://github.com/paritytech/substrate/issues/6845 for details). Thus there is no need to require sentry node uptime.