### PR TITLE
Fix ensureUpgrades

### DIFF
--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -71,7 +71,12 @@ export default class Monitor {
       const latestVersion = semver.clean(this.latestTaggedRelease.name);
       logger.info(`${name} | version: ${nodeVersion} latest: ${latestVersion}`);
 
-      if (!nodeVersion) return;
+      if (!nodeVersion) {
+        if (updated) {
+          await this.db.reportNotUpdated(name);
+        }
+        continue;
+      }
 
       const isUpgraded = semver.gte(nodeVersion, latestVersion);
 


### PR DESCRIPTION
The check process will be terminated improperly If the nodeVersion of the node is null.
It should continue, not return, to check the rest of the nodes.