### PR TITLE
Add Constraint Additions

### DIFF
--- a/charts/otv-backend/Chart.yaml
+++ b/charts/otv-backend/Chart.yaml
@@ -1,4 +1,4 @@
 description: 1K Validators Backend
 name: otv-backend
-version: v2.2.49
+version: v2.2.50
 apiVersion: v2

--- a/config/main.sample.json
+++ b/config/main.sample.json
@@ -15,9 +15,10 @@
     "cron": {
         "monitor": "0 */15 * * * *",
         "clearOffline": "0 0 0 * * 0",
-        "validity": "0 0-59/7 * * * *",
+        "validity": "0 0-59/1 * * * *",
         "execution": "0 0-59/1 * * * *",
-        "scorekeeper": "0 0-59/1 * * * *"
+        "scorekeeper": "0 0-59/1 * * * *",
+        "candidateChainData": "0 0-59/1 * * * *"
     },
     "db": {
         "migrate": false,

--- a/config/main.sample.json
+++ b/config/main.sample.json
@@ -18,7 +18,8 @@
         "validity": "0 0-59/1 * * * *",
         "execution": "0 0-59/1 * * * *",
         "scorekeeper": "0 0-59/1 * * * *",
-        "candidateChainData": "0 0-59/1 * * * *"
+        "candidateChainData": "0 0-59/1 * * * *",
+        "rewardClaiming": "0 0-59/3 * * * *"
     },
     "db": {
         "migrate": false,

--- a/config/secret.sample.json
+++ b/config/secret.sample.json
@@ -38,6 +38,7 @@
                     "maxNominations": 1
                 }
             ]
-        ]
+        ],
+        "claimer": {"seed": "card insect figure furnace better miracle lend monitor call inner half top"}
     }
 }

--- a/helmfile.d/10-otv-backend.yaml
+++ b/helmfile.d/10-otv-backend.yaml
@@ -11,7 +11,7 @@ releases:
     namespace: kusama
     {{ if eq .Environment.Name "production" }}
     chart: w3f/otv-backend
-    version: v2.2.49
+    version: v2.2.50
     {{ else }}
     chart: ../charts/otv-backend
     {{ end }}
@@ -22,7 +22,7 @@ releases:
     namespace: polkadot
     {{ if eq .Environment.Name "production" }}
     chart: w3f/otv-backend
-    version: v2.2.49
+    version: v2.2.50
     {{ else }}
     chart: ../charts/otv-backend
     {{ end }} 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1k-validators-be",
-  "version": "2.2.49",
+  "version": "2.2.50",
   "description": "Services for running the Thousand Validator Program.",
   "main": "index.js",
   "scripts": {

--- a/src/chaindata.ts
+++ b/src/chaindata.ts
@@ -299,6 +299,12 @@ class ChainData {
     return ledger.toJSON().stash;
   };
 
+  getControllerFromStash = async(stash:string): Promise<string | null> => {
+    const api = await this.handler.getApi();
+    const controller = await api.query.staking.bonded(stash);
+    return controller.toString();
+  }
+
   /**
    * Gets Nominations for a nomiantor at a given era
    * @param nominatorStash
@@ -354,6 +360,57 @@ class ChainData {
       bonded: bonded,
     };
   };
+
+  /**
+   * Gets unclaimed eras for a validator
+   * To check this, we query the ledger for claimedEras, which are the eras the validator has claiemd rewards for.
+   * We then check for the history depth eras if they have earned era points for an era (which would indicate they are active)
+   * and check to see if that era is included in the claimedEras. If not, it is an unclaimed era, and pushed to an unclaimed era 
+   * set that is returned.
+   * @param validatorStash 
+   * @returns 
+   */
+  getUnclaimedEras = async(validatorStash: string) => {
+    const api = await this.handler.getApi();
+    const controller = await this.getControllerFromStash(validatorStash);
+    if (!controller) {
+      logger.info(`{Chaindata::getUnclaimedEras} ${validatorStash} does not have a controller`);
+      return;
+    }
+
+    const ledger:JSON = (await api.query.staking.ledger(controller)).toJSON();
+    if (!ledger) {
+        logger.info(`{Chaindata::getUnclaimedRewards} ${validatorStash} and controller ${controller} doesn't have a ledger`);
+        return;
+    } 
+
+    const [currentEra, err] = await this.getActiveEraIndex();
+    const claimedEras = ledger ? ledger.claimedRewards: null;
+    let erasActive = [];
+    let unclaimedEras = [];
+
+    const startingEra = currentEra - 84 >= 0 ? currentEra - 84 : 0;
+    for (let i = startingEra; i < currentEra; i++){
+        const eraPoints:JSON = (await api.query.staking.erasRewardPoints(i)).toJSON().individual;
+        let eraPointsValue;
+        
+        for (const val in eraPoints){
+            if (val.toString() == validatorStash.toString() || val.toString() == controller.toString()) {
+                erasActive.push(i);
+                eraPointsValue = eraPoints[val];
+            }
+        }
+    }
+
+    for (const era of erasActive){
+        if (!claimedEras.includes(era)){
+            unclaimedEras.push(era);
+        }
+    }
+  
+    return unclaimedEras;
+  }
+
 }
 
 export default ChainData;

--- a/src/claimer.ts
+++ b/src/claimer.ts
@@ -1,113 +1,111 @@
 import { Keyring } from "@polkadot/api";
 import ApiHandler from "./ApiHandler";
 import { ClaimerConfig, EraReward, Stash } from "./types";
-import Database from './db';
+import Database from "./db";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { SubmittableExtrinsic } from "@polkadot/api/types";
 import logger from "./logger";
 import { sleep } from "./util";
 import MatrixBot from "./matrix";
 
-
-
 export default class Claimer {
+  private db: Database;
+  private handler: ApiHandler;
+  private signer: KeyringPair;
+  private bot: any;
 
-    private db: Database;
-    private handler: ApiHandler;
-    private signer: KeyringPair;
-    private bot: any;
+  constructor(
+    handler: ApiHandler,
+    db: Database,
+    cfg: ClaimerConfig,
+    networkPrefix = 2,
+    bot?: any
+  ) {
+    this.handler = handler;
+    this.db = db;
 
-    constructor(
-        handler: ApiHandler,
-        db: Database,
-        cfg: ClaimerConfig,
-        networkPrefix = 2,
-        bot?: any
-      ) {
-        this.handler = handler;
-        this.db = db;
-    
-        const keyring = new Keyring({
-          type: "sr25519",
-        });
-    
-        keyring.setSS58Format(networkPrefix);
-    
-        this.signer = keyring.createFromUri(cfg.seed);
+    const keyring = new Keyring({
+      type: "sr25519",
+    });
 
-        logger.info(
-          `(Claimer::constructor) claimer signer spawned: ${this.address}`
-        );
+    keyring.setSS58Format(networkPrefix);
+
+    this.signer = keyring.createFromUri(cfg.seed);
+
+    logger.info(
+      `(Claimer::constructor) claimer signer spawned: ${this.address}`
+    );
+  }
+
+  public async claim(unclaimedEras: EraReward[]): Promise<boolean> {
+    const api = await this.handler.getApi();
+    console.log(`eras to claim: ${unclaimedEras}`);
+    for (const era of unclaimedEras) {
+      const tx = api.tx.staking.payoutStakers(era.stash, era.era);
+      await this.sendClaimTx(tx, era);
+      await sleep(4000);
     }
+    return true;
+  }
 
-    public async claim(unclaimedEras: EraReward[]): Promise<boolean> {
-      const api = await this.handler.getApi();
-      console.log(`eras to claim: ${unclaimedEras}`);
-      for (const era of unclaimedEras){
-        const tx = api.tx.staking.payoutStakers(era.stash, era.era);
-        await this.sendClaimTx(tx, era);
-        await sleep(4000);
-      }
-        return true;
-    }
+  public get address(): string {
+    return this.signer.address;
+  }
 
-    public get address(): string {
-        return this.signer.address;
-    }
+  sendClaimTx = async (
+    tx: SubmittableExtrinsic<"promise">,
+    unclaimedEras: EraReward
+  ): Promise<boolean> => {
+    try {
+      const unsub = await tx.signAndSend(this.signer, async (result: any) => {
+        // TODO: Check result of Tx - either 'ExtrinsicSuccess' or 'ExtrinsicFail'
+        //  - If the extrinsic fails, this needs some error handling / logging added
 
-    sendClaimTx = async(
-        tx: SubmittableExtrinsic<"promise">,
-        unclaimedEras: EraReward
-        ):Promise<boolean> => {
+        const { status } = result;
 
-            
+        logger.info(`(Claimer::sendClaimTx) Status now: ${status.type}`);
+        if (status.isFinalized) {
+          const finalizedBlockHash = status.asFinalized;
+          logger.info(
+            `(Claimer::sendClaimTx) Included in block ${finalizedBlockHash}`
+          );
+          const faultReason = `Era ${unclaimedEras.era} had to be claimed`;
+          await this.db.pushFaultEvent(unclaimedEras.stash, faultReason);
+          await this.dockPoints(unclaimedEras.stash, unclaimedEras.era);
 
-          try {
-            const unsub = await tx.signAndSend(this.signer, async (result: any) => {
-              // TODO: Check result of Tx - either 'ExtrinsicSuccess' or 'ExtrinsicFail'
-              //  - If the extrinsic fails, this needs some error handling / logging added
-      
-              const { status } = result;
-      
-              logger.info(`(Claimer::sendClaimTx) Status now: ${status.type}`);
-              if (status.isFinalized) {
-                const finalizedBlockHash = status.asFinalized;
-                logger.info(
-                  `(Claimer::sendClaimTx) Included in block ${finalizedBlockHash}`
-                );
-                const faultReason = `Era ${unclaimedEras.era} had to be claimed`;
-                await this.db.pushFaultEvent(unclaimedEras.stash, faultReason);
-                await this.dockPoints(unclaimedEras.stash, unclaimedEras.era);
-      
-                await this.db.setBotClaimEvent(unclaimedEras.stash, unclaimedEras.era, finalizedBlockHash);
-      
-                unsub();
-              }
-            });
-      
-            return true;
-          } catch (err) {
-            logger.warn(`Nominate tx failed: ${err}`);
-            return false;
-          }
+          await this.db.setBotClaimEvent(
+            unclaimedEras.stash,
+            unclaimedEras.era,
+            finalizedBlockHash
+          );
 
-
-            return true;
+          unsub();
         }
+      });
 
-          /// Handles the docking of points from bad behaving validators.
+      return true;
+    } catch (err) {
+      logger.warn(`Nominate tx failed: ${err}`);
+      return false;
+    }
+
+    return true;
+  };
+
+  /// Handles the docking of points from bad behaving validators.
   async dockPoints(stash: Stash, era: number): Promise<boolean> {
     await this.db.dockPointsUnclaimedReward(stash);
 
     const candidate = await this.db.getCandidate(stash);
-    logger.info(`${candidate.name} docked points for not claiming era: ${era}. New rank: ${candidate.rank}`);
-    if (this.bot){
-      await this.bot.sendMessage(`${candidate.name} docked points for not claiming era: ${era}. New rank: ${candidate.rank}`);
+    logger.info(
+      `${candidate.name} docked points for not claiming era: ${era}. New rank: ${candidate.rank}`
+    );
+    if (this.bot) {
+      await this.bot.sendMessage(
+        `${candidate.name} docked points for not claiming era: ${era}. New rank: ${candidate.rank}`
+      );
     }
 
     return true;
   }
-    
-
-
 }

--- a/src/claimer.ts
+++ b/src/claimer.ts
@@ -1,0 +1,113 @@
+import { Keyring } from "@polkadot/api";
+import ApiHandler from "./ApiHandler";
+import { ClaimerConfig, EraReward, Stash } from "./types";
+import Database from './db';
+import { KeyringPair } from "@polkadot/keyring/types";
+import { SubmittableExtrinsic } from "@polkadot/api/types";
+import logger from "./logger";
+import { sleep } from "./util";
+import MatrixBot from "./matrix";
+
+
+
+export default class Claimer {
+
+    private db: Database;
+    private handler: ApiHandler;
+    private signer: KeyringPair;
+    private bot: any;
+
+    constructor(
+        handler: ApiHandler,
+        db: Database,
+        cfg: ClaimerConfig,
+        networkPrefix = 2,
+        bot?: any
+      ) {
+        this.handler = handler;
+        this.db = db;
+    
+        const keyring = new Keyring({
+          type: "sr25519",
+        });
+    
+        keyring.setSS58Format(networkPrefix);
+    
+        this.signer = keyring.createFromUri(cfg.seed);
+
+        logger.info(
+          `(Claimer::constructor) claimer signer spawned: ${this.address}`
+        );
+    }
+
+    public async claim(unclaimedEras: EraReward[]): Promise<boolean> {
+      const api = await this.handler.getApi();
+      console.log(`eras to claim: ${unclaimedEras}`);
+      for (const era of unclaimedEras){
+        const tx = api.tx.staking.payoutStakers(era.stash, era.era);
+        await this.sendClaimTx(tx, era);
+        await sleep(4000);
+      }
+        return true;
+    }
+
+    public get address(): string {
+        return this.signer.address;
+    }
+
+    sendClaimTx = async(
+        tx: SubmittableExtrinsic<"promise">,
+        unclaimedEras: EraReward
+        ):Promise<boolean> => {
+
+            
+
+          try {
+            const unsub = await tx.signAndSend(this.signer, async (result: any) => {
+              // TODO: Check result of Tx - either 'ExtrinsicSuccess' or 'ExtrinsicFail'
+              //  - If the extrinsic fails, this needs some error handling / logging added
+      
+              const { status } = result;
+      
+              logger.info(`(Claimer::sendClaimTx) Status now: ${status.type}`);
+              if (status.isFinalized) {
+                const finalizedBlockHash = status.asFinalized;
+                logger.info(
+                  `(Claimer::sendClaimTx) Included in block ${finalizedBlockHash}`
+                );
+                const faultReason = `Era ${unclaimedEras.era} had to be claimed`;
+                await this.db.pushFaultEvent(unclaimedEras.stash, faultReason);
+                await this.dockPoints(unclaimedEras.stash, unclaimedEras.era);
+      
+                await this.db.setBotClaimEvent(unclaimedEras.stash, unclaimedEras.era, finalizedBlockHash);
+      
+                unsub();
+              }
+            });
+      
+            return true;
+          } catch (err) {
+            logger.warn(`Nominate tx failed: ${err}`);
+            return false;
+          }
+
+
+            return true;
+        }
+
+          /// Handles the docking of points from bad behaving validators.
+  async dockPoints(stash: Stash, era: number): Promise<boolean> {
+    await this.db.dockPointsUnclaimedReward(stash);
+
+    const candidate = await this.db.getCandidate(stash);
+    logger.info(`${candidate.name} docked points for not claiming era: ${era}. New rank: ${candidate.rank}`);
+    if (this.bot){
+      await this.bot.sendMessage(`${candidate.name} docked points for not claiming era: ${era}. New rank: ${candidate.rank}`);
+    }
+
+    return true;
+  }
+    
+
+
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export type Config = {
     validity: string;
     execution: string;
     scorekeeper: string;
+    candidateChainData: string;
   };
   db: {
     mongo: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import path from "path";
+import { ClaimerConfig } from "./types";
 
 type CandidateConfig = {
   name: string;
@@ -31,6 +32,7 @@ export type Config = {
     execution: string;
     scorekeeper: string;
     candidateChainData: string;
+    rewardClaiming: string;
   };
   db: {
     mongo: {
@@ -59,6 +61,7 @@ export type Config = {
     forceRound: boolean;
     nominating: boolean;
     nominators: NominatorConfig[][];
+    claimer: ClaimerConfig;
   };
   server: {
     port: number;
@@ -86,6 +89,7 @@ export const loadConfigDir = (configDir: string): Config => {
 
   mainConf.matrix.accessToken = secretConf.matrix.accessToken;
   mainConf.scorekeeper.nominators = secretConf.scorekeeper.nominators;
+  mainConf.scorekeeper.claimer = secretConf.scorekeeper.claimer;
 
   return mainConf;
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,9 @@ export const KUSAMA_FOUR_DAYS_ERAS = 16;
 /// Number of Eras in 4 days that a validator should have claimed all previous rewards except
 export const POLKADOT_FOUR_DAYS_ERAS = 4;
 
+// Number of eras that a validator can have unclaimed rewards for until the backend tries to claim them
+export const REWARD_CLAIMING_THRESHOLD = 64;
+
 /// On Kusama eras are 6 hours with 6 second blocks.
 export const KUSAMA_APPROX_ERA_LENGTH_IN_BLOCKS = 3600;
 
@@ -67,3 +70,6 @@ export const EXECUTION_CRON = "0 0-59/15 * * * *";
 
 // Scorekeeper Cron Job. This runs every 10 minutes by default
 export const SCOREKEEPER_CRON = "0 0-59/10 * * * *";
+
+// Reward claiming frequency. This runs every 30 minutes by default
+export const REWARD_CLAIMING_CRON = "0 0-59/30 * * * *";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -58,6 +58,10 @@ export const CLEAR_OFFLINE_CRON = "0 0 0 * * 0";
 // Validity Cron Job. This runs every 7 minutes by default
 export const VALIDITY_CRON = "0 0-59/7 * * * *";
 
+// Candidate ChainData Cron Job. This runs ever 5 minutes by default
+// Validity Cron Job. This runs every 7 minutes by default
+export const CANDIDATE_CHAINDATA_CRON = "0 0-59/5 * * * *";
+
 // Execution Cron Job. This runs every 15 minutes by default
 export const EXECUTION_CRON = "0 0-59/15 * * * *";
 

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -213,12 +213,12 @@ export class OTV implements Constraints {
 
     const unclaimedEras = await this.chaindata.getUnclaimedEras(stash);
     const [currentEra, err3] = await this.chaindata.getActiveEraIndex();
-    const threshold = currentEra - this.unclaimedEraThreshold; // Validators cannot have unclaimed rewards before this era
+    const threshold = currentEra - this.unclaimedEraThreshold - 1; // Validators cannot have unclaimed rewards before this era
     // If unclaimed eras contain an era below the recent threshold
-    if (!unclaimedEras.every((era) => (era) => threshold)) {
+    if (!unclaimedEras.every((era) => (era) > threshold)) {
       return [
         false,
-        `${stash} has unclaimed eras: ${unclaimedEras} prior to era: ${threshold}`,
+        `${stash} has unclaimed eras: ${unclaimedEras} prior to era: ${threshold+1}`,
       ];
     }
 
@@ -383,10 +383,10 @@ export class OTV implements Constraints {
 
       const unclaimedEras = await this.chaindata.getUnclaimedEras(stash);
       const [currentEra, err2] = await this.chaindata.getActiveEraIndex();
-      const threshold = currentEra - this.unclaimedEraThreshold * 2; // Validators cannot have unclaimed rewards before this era for polkadot
+      const threshold = (currentEra - this.unclaimedEraThreshold * 2) - 1; // Validators cannot have unclaimed rewards before this era
       // If unclaimed eras contain an era below the recent threshold
-      if (!unclaimedEras.every((era) => (era) => threshold)) {
-        const reason = `${stash} has unclaimed eras: ${unclaimedEras} prior to: ${threshold} (era: ${currentEra})`;
+      if (!unclaimedEras.every((era) => (era) > threshold)) {
+        const reason = `${stash} has unclaimed eras: ${unclaimedEras} prior to: ${threshold+1} (era: ${currentEra})`;
         bad.add({ candidate, reason });
         continue;
       }

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -215,10 +215,12 @@ export class OTV implements Constraints {
     const [currentEra, err3] = await this.chaindata.getActiveEraIndex();
     const threshold = currentEra - this.unclaimedEraThreshold - 1; // Validators cannot have unclaimed rewards before this era
     // If unclaimed eras contain an era below the recent threshold
-    if (!unclaimedEras.every((era) => (era) > threshold)) {
+    if (!unclaimedEras.every((era) => era > threshold)) {
       return [
         false,
-        `${stash} has unclaimed eras: ${unclaimedEras} prior to era: ${threshold+1}`,
+        `${stash} has unclaimed eras: ${unclaimedEras} prior to era: ${
+          threshold + 1
+        }`,
       ];
     }
 
@@ -383,10 +385,12 @@ export class OTV implements Constraints {
 
       const unclaimedEras = await this.chaindata.getUnclaimedEras(stash);
       const [currentEra, err2] = await this.chaindata.getActiveEraIndex();
-      const threshold = (currentEra - this.unclaimedEraThreshold * 2) - 1; // Validators cannot have unclaimed rewards before this era
+      const threshold = currentEra - this.unclaimedEraThreshold * 2 - 1; // Validators cannot have unclaimed rewards before this era
       // If unclaimed eras contain an era below the recent threshold
-      if (!unclaimedEras.every((era) => (era) > threshold)) {
-        const reason = `${stash} has unclaimed eras: ${unclaimedEras} prior to: ${threshold+1} (era: ${currentEra})`;
+      if (!unclaimedEras.every((era) => era > threshold)) {
+        const reason = `${stash} has unclaimed eras: ${unclaimedEras} prior to: ${
+          threshold + 1
+        } (era: ${currentEra})`;
         bad.add({ candidate, reason });
         continue;
       }

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -176,6 +176,7 @@ export class OTV implements Constraints {
       ];
     }
 
+    // Ensure that the reward destination is set to 'Staked'
     if (!this.skipStakedDesitnation) {
       const isStaked = await this.chaindata.destinationIsStaked(stash);
       if (!isStaked) {
@@ -184,6 +185,7 @@ export class OTV implements Constraints {
       }
     }
 
+    // Ensure that the commission is in line with the network rules
     const [commission, err] = await this.chaindata.getCommission(stash);
     if (err) {
       return [false, `${name} ${err}`];
@@ -215,10 +217,17 @@ export class OTV implements Constraints {
 
         const res = await axios.get(url);
 
+        if (!!res.data.invalidityResasons){
+          return [
+            false,
+            `${name} has a kusama node that is invalid: ${res.data.invalidityReasons}`
+          ]
+        }
+
         if (Number(res.data.rank) < 25) {
           return [
             false,
-            `${name} has a Kusama stash with lower than 25 rank in the Kusama OTV programme.`,
+            `${name} has a Kusama stash with lower than 25 rank in the Kusama OTV programme: ${res.data.rank}.`,
           ];
         }
       }

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -286,14 +286,12 @@ export class OTV implements Constraints {
       }
     );
 
+    // Sort so that validators with few unclaimed payouts are prioritized
     validCandidates = validCandidates.sort(
       (a: CandidateData, b: CandidateData) => {
-        // console.log(`Candidate a: ${a}`);
-        // console.log(`Candidate b: ${b}`);
         return a.unclaimedEras.length - b.unclaimedEras.length;
       }
     );
-    console.log(validCandidates);
 
     // Cache the value to return from the server.
     this.validCache = validCandidates;

--- a/src/constraints.ts
+++ b/src/constraints.ts
@@ -215,11 +215,12 @@ export class OTV implements Constraints {
     const [currentEra, err3] = await this.chaindata.getActiveEraIndex();
     const threshold = currentEra - this.unclaimedEraThreshold; // Validators cannot have unclaimed rewards before this era
     // If unclaimed eras contain an era below the recent threshold
-    if (!unclaimedEras.every(era => era => threshold)){
-      return [false,
-      `${stash} has unclaimed eras: ${unclaimedEras} prior to era: ${threshold}`,
-    ];
-    } 
+    if (!unclaimedEras.every((era) => (era) => threshold)) {
+      return [
+        false,
+        `${stash} has unclaimed eras: ${unclaimedEras} prior to era: ${threshold}`,
+      ];
+    }
 
     try {
       if (!!kusamaStash) {
@@ -382,14 +383,13 @@ export class OTV implements Constraints {
 
       const unclaimedEras = await this.chaindata.getUnclaimedEras(stash);
       const [currentEra, err2] = await this.chaindata.getActiveEraIndex();
-      const threshold = currentEra - (this.unclaimedEraThreshold * 2); // Validators cannot have unclaimed rewards before this era for polkadot
+      const threshold = currentEra - this.unclaimedEraThreshold * 2; // Validators cannot have unclaimed rewards before this era for polkadot
       // If unclaimed eras contain an era below the recent threshold
-      if (!unclaimedEras.every(era => era => threshold)){
+      if (!unclaimedEras.every((era) => (era) => threshold)) {
         const reason = `${stash} has unclaimed eras: ${unclaimedEras} prior to: ${threshold} (era: ${currentEra})`;
-        bad.add({candidate, reason});
+        bad.add({ candidate, reason });
         continue;
       }
-
 
       // Checking for slashing should be temporarily removed - since slashes can be cancelled by governance they should be handled manually.
 

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -8,6 +8,7 @@ import {
   SIXTEEN_HOURS,
   TIME_DELAY_BLOCKS,
   VALIDITY_CRON,
+  CANDIDATE_CHAINDATA_CRON
 } from "./constants";
 import logger from "./logger";
 import Monitor from "./monitor";
@@ -15,6 +16,7 @@ import { Config } from "./config";
 import { OTV } from "./constraints";
 import ApiHandler from "./ApiHandler";
 import Nominator from "./nominator";
+import ChainData from "./chaindata";
 
 // Monitors the latest GitHub releases and ensures nodes have upgraded
 // within a timely period.
@@ -170,3 +172,41 @@ export const startExecutionJob = async (
   });
   executionCron.start();
 };
+
+// Chron job for writing chaindata for candidates to the db
+// This updates:
+//     - Unclaimed eras
+export const startCandidateChainDataJob = async(  config: Config,
+  handler: ApiHandler,
+  db: Db,
+  constraints: OTV, chaindata: ChainData) => {
+    logger.info(`(cron::CandidateChainData) Running candidate chain data cron`);
+
+    const chaindataFrequency = config.cron.candidateChainData
+    ? config.cron.candidateChainData
+    : CANDIDATE_CHAINDATA_CRON;
+  
+    logger.info(`(cron::CandidateChainData) Running candidate chain data cron with frequency: ${chaindataFrequency}`);
+  
+    const api = await handler.getApi();
+  
+    const chaindataCron = new CronJob(chaindataFrequency, async () => {
+      logger.info(`{cron::CandidateChainData} running candidate chain data cron....`);
+
+      const allCandidates = await db.allCandidates();
+      for (const candidate of allCandidates){
+
+        const unclaimedEras = await chaindata.getUnclaimedEras(candidate.stash);
+        await db.setUnclaimedEras(candidate.stash, unclaimedEras);
+
+        // TODO: add setting commission
+        // TODO add setting identity information
+        // TODO add setting eras data
+
+      }
+    });
+    chaindataCron.start();
+
+
+    
+  }

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -187,7 +187,6 @@ export const startCandidateChainDataJob = async (
   constraints: OTV,
   chaindata: ChainData
 ) => {
-
   const chaindataFrequency = config.cron.candidateChainData
     ? config.cron.candidateChainData
     : CANDIDATE_CHAINDATA_CRON;
@@ -224,7 +223,6 @@ export const startRewardClaimJob = async (
   claimer: Claimer,
   chaindata: ChainData
 ) => {
-
   const rewardClaimingFrequency = config.cron.rewardClaiming
     ? config.cron.rewardClaiming
     : REWARD_CLAIMING_CRON;
@@ -239,25 +237,29 @@ export const startRewardClaimJob = async (
     logger.info(
       `{cron::CandidateChainData} running candidate chain data cron....`
     );
-    
+
     const erasToClaim = [];
     const [currentEra, err] = await chaindata.getActiveEraIndex();
-    const rewardClaimThreshold = config.global.networkPrefix == 2 || config.global.networkPrefix == 0 ? REWARD_CLAIMING_THRESHOLD : 6;
+    const rewardClaimThreshold =
+      config.global.networkPrefix == 2 || config.global.networkPrefix == 0
+        ? REWARD_CLAIMING_THRESHOLD
+        : 6;
     const claimThreshold = currentEra - rewardClaimThreshold;
 
     const allCandidates = await db.allCandidates();
     for (const candidate of allCandidates) {
       const unclaimedEras = await chaindata.getUnclaimedEras(candidate.stash);
       for (const era of unclaimedEras) {
-        if (era < claimThreshold){
-          logger.info(`{cron::startRewardClaimJob} added era ${era} for validator ${candidate.stash} to be claimed.`);
-          const eraReward: EraReward = {era: era, stash: candidate.stash}
+        if (era < claimThreshold) {
+          logger.info(
+            `{cron::startRewardClaimJob} added era ${era} for validator ${candidate.stash} to be claimed.`
+          );
+          const eraReward: EraReward = { era: era, stash: candidate.stash };
           erasToClaim.push(eraReward);
         }
       }
-
     }
-    if (erasToClaim.length > 0){
+    if (erasToClaim.length > 0) {
       await claimer.claim(erasToClaim);
     }
   });

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -8,7 +8,7 @@ import {
   SIXTEEN_HOURS,
   TIME_DELAY_BLOCKS,
   VALIDITY_CRON,
-  CANDIDATE_CHAINDATA_CRON
+  CANDIDATE_CHAINDATA_CRON,
 } from "./constants";
 import logger from "./logger";
 import Monitor from "./monitor";
@@ -176,37 +176,39 @@ export const startExecutionJob = async (
 // Chron job for writing chaindata for candidates to the db
 // This updates:
 //     - Unclaimed eras
-export const startCandidateChainDataJob = async(  config: Config,
+export const startCandidateChainDataJob = async (
+  config: Config,
   handler: ApiHandler,
   db: Db,
-  constraints: OTV, chaindata: ChainData) => {
-    logger.info(`(cron::CandidateChainData) Running candidate chain data cron`);
+  constraints: OTV,
+  chaindata: ChainData
+) => {
+  logger.info(`(cron::CandidateChainData) Running candidate chain data cron`);
 
-    const chaindataFrequency = config.cron.candidateChainData
+  const chaindataFrequency = config.cron.candidateChainData
     ? config.cron.candidateChainData
     : CANDIDATE_CHAINDATA_CRON;
-  
-    logger.info(`(cron::CandidateChainData) Running candidate chain data cron with frequency: ${chaindataFrequency}`);
-  
-    const api = await handler.getApi();
-  
-    const chaindataCron = new CronJob(chaindataFrequency, async () => {
-      logger.info(`{cron::CandidateChainData} running candidate chain data cron....`);
 
-      const allCandidates = await db.allCandidates();
-      for (const candidate of allCandidates){
+  logger.info(
+    `(cron::CandidateChainData) Running candidate chain data cron with frequency: ${chaindataFrequency}`
+  );
 
-        const unclaimedEras = await chaindata.getUnclaimedEras(candidate.stash);
-        await db.setUnclaimedEras(candidate.stash, unclaimedEras);
+  const api = await handler.getApi();
 
-        // TODO: add setting commission
-        // TODO add setting identity information
-        // TODO add setting eras data
+  const chaindataCron = new CronJob(chaindataFrequency, async () => {
+    logger.info(
+      `{cron::CandidateChainData} running candidate chain data cron....`
+    );
 
-      }
-    });
-    chaindataCron.start();
+    const allCandidates = await db.allCandidates();
+    for (const candidate of allCandidates) {
+      const unclaimedEras = await chaindata.getUnclaimedEras(candidate.stash);
+      await db.setUnclaimedEras(candidate.stash, unclaimedEras);
 
-
-    
-  }
+      // TODO: add setting commission
+      // TODO add setting identity information
+      // TODO add setting eras data
+    }
+  });
+  chaindataCron.start();
+};

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,7 +8,7 @@ import {
   NominatorSchema,
   NominationSchema,
   ChainMetadataSchema,
-  BotClaimEventSchema
+  BotClaimEventSchema,
 } from "./models";
 import logger from "../logger";
 
@@ -39,7 +39,10 @@ export default class Db {
       "ChainMetadata",
       ChainMetadataSchema
     );
-    this.botClaimEventModel = mongoose.model("BotClaimEvent", BotClaimEventSchema);
+    this.botClaimEventModel = mongoose.model(
+      "BotClaimEvent",
+      BotClaimEventSchema
+    );
   }
 
   static async create(uri = "mongodb://localhost:27017/otv"): Promise<Db> {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -565,6 +565,27 @@ export default class Db {
     return true;
   }
 
+  async setUnclaimedEras(
+    stash: string,
+    unclaimedEras: number[]
+  ): Promise<boolean> {
+    logger.info(
+      `(Db::setNomination) Setting unclaimed eras for ${stash} to the following validators: ${unclaimedEras}`
+    );
+    await this.candidateModel
+      .findOneAndUpdate(
+        {
+          stash,
+        },
+        {
+          unclaimedEras: unclaimedEras,
+        }
+      )
+      .exec();
+
+    return true;
+  }
+
   async setNomination(
     address: string,
     era: number,

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -570,7 +570,7 @@ export default class Db {
     unclaimedEras: number[]
   ): Promise<boolean> {
     logger.info(
-      `(Db::setNomination) Setting unclaimed eras for ${stash} to the following validators: ${unclaimedEras}`
+      `(Db::setUnclaimedEras) Setting unclaimed eras for ${stash} to the following validators: ${unclaimedEras}`
     );
     await this.candidateModel
       .findOneAndUpdate(

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -647,7 +647,7 @@ export default class Db {
     blockHash: string
   ): Promise<boolean> {
     logger.info(
-      `(Db::setBotClaimEvent) Setting bot claim event for ${address} for era ${era}.`
+      `(Db::setBotClaimEvent) Setting bot claim event for ${address} for era ${era} with blockhash: ${blockHash}.`
     );
 
     const data = await this.botClaimEventModel.findOne({
@@ -914,5 +914,9 @@ export default class Db {
 
   async getChainMetadata(): Promise<any> {
     return this.chainMetadataModel.findOne({ name: /.*/ }).exec();
+  }
+
+  async getBotClaimEvents(): Promise<any> {
+    return this.botClaimEventModel.find({ address: /.*/ }).exec();
   }
 }

--- a/src/db/models.ts
+++ b/src/db/models.ts
@@ -133,5 +133,5 @@ export const BotClaimEventSchema = new Schema({
   // The timestamp the event occured
   timestamp: Number,
   // The finalized blockhash of the Claim tx
-  blockhash: String,
+  blockHash: String,
 });

--- a/src/db/models.ts
+++ b/src/db/models.ts
@@ -81,6 +81,8 @@ export const CandidateSchema = new Schema({
   faultEvents: { type: [FaultEventSchema], default: [] },
   // If a validator had its rank increased, this will contian details.
   rankEvents: { type: [RankEventSchema], default: [] },
+  // Unclaimed Era Rewards
+  unclaimedEras: {type:[Number], default: []},
   // Polkadot specific: Kusama Stash
   kusamaStash: String,
   // Polkadot specific: Case for good intentions

--- a/src/db/models.ts
+++ b/src/db/models.ts
@@ -123,3 +123,15 @@ export const ChainMetadataSchema = new Schema({
   // Chain name
   name: String,
 });
+
+// A historical event when the bot will claim a reward on behalf of a nominator
+export const BotClaimEventSchema = new Schema({
+  // Validator Address
+  address: String,
+  // The era the reward was claimed for
+  era: Number,
+  // The timestamp the event occured
+  timestamp: Number,
+  // The finalized blockhash of the Claim tx
+  blockhash: String,
+})

--- a/src/db/models.ts
+++ b/src/db/models.ts
@@ -134,4 +134,4 @@ export const BotClaimEventSchema = new Schema({
   timestamp: Number,
   // The finalized blockhash of the Claim tx
   blockhash: String,
-})
+});

--- a/src/db/models.ts
+++ b/src/db/models.ts
@@ -82,7 +82,7 @@ export const CandidateSchema = new Schema({
   // If a validator had its rank increased, this will contian details.
   rankEvents: { type: [RankEventSchema], default: [] },
   // Unclaimed Era Rewards
-  unclaimedEras: {type:[Number], default: []},
+  unclaimedEras: { type: [Number], default: [] },
   // Polkadot specific: Kusama Stash
   kusamaStash: String,
   // Polkadot specific: Case for good intentions

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,13 @@ const start = async (cmd: { config: string }) => {
     await scorekeeper.addNominatorGroup(nominatorGroup);
   }
 
+  if (config.scorekeeper.claimer){
+    logger.info(`Claimer in config. Adding to scorekeeper`);
+    // Setup claimer in the scorekeeper
+    await scorekeeper.addClaimer(config.scorekeeper.claimer);
+  }
+
+
   const curControllers = scorekeeper.getAllNominatorControllers();
   await db.removeStaleNominators(curControllers);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,12 +107,11 @@ const start = async (cmd: { config: string }) => {
     await scorekeeper.addNominatorGroup(nominatorGroup);
   }
 
-  if (config.scorekeeper.claimer){
+  if (config.scorekeeper.claimer) {
     logger.info(`Claimer in config. Adding to scorekeeper`);
     // Setup claimer in the scorekeeper
     await scorekeeper.addClaimer(config.scorekeeper.claimer);
   }
-
 
   const curControllers = scorekeeper.getAllNominatorControllers();
   await db.removeStaleNominators(curControllers);

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,5 +156,5 @@ program
   .option("--config <directory>", "The path to the config directory.", "config")
   .action((cmd: { config: string }) => catchAndQuit(start(cmd)));
 
-program.version("2.2.49");
+program.version("2.2.50");
 program.parse(process.argv);

--- a/src/misc/testSetup.ts
+++ b/src/misc/testSetup.ts
@@ -70,7 +70,11 @@ export const startTestSetup = async () => {
     },
   ];
 
-  const claimer = {seed:"card insect figure furnace better miracle lend monitor call inner half top", address: "15B4rygvyb1BdA33AatuT7btLiZSUfcAS14X1SLrDfpq8Eou"};
+  const claimer = {
+    seed:
+      "card insect figure furnace better miracle lend monitor call inner half top",
+    address: "15B4rygvyb1BdA33AatuT7btLiZSUfcAS14X1SLrDfpq8Eou",
+  };
 
   const nodes = [
     {
@@ -139,15 +143,21 @@ export const startTestSetup = async () => {
   ];
 
   // Send funds to reward claimer:
-  console.log(`{TestSetup::RewardClaimer} Sending funds to reward claimer address: ${claimer.address}`);
+  console.log(
+    `{TestSetup::RewardClaimer} Sending funds to reward claimer address: ${claimer.address}`
+  );
   const claimerTransfer = api.tx.balances.transfer(
     claimer.address,
     "12345678912345"
   );
   try {
-    const hash = await claimerTransfer.signAndSend(keyring.addFromUri("//Alice"));
+    const hash = await claimerTransfer.signAndSend(
+      keyring.addFromUri("//Alice")
+    );
   } catch {
-    console.log(`{TestSetup::Reward::${claimer.address}} transfer tx failed...`);
+    console.log(
+      `{TestSetup::Reward::${claimer.address}} transfer tx failed...`
+    );
   }
   await sleep(3000);
 

--- a/src/misc/testSetup.ts
+++ b/src/misc/testSetup.ts
@@ -70,6 +70,8 @@ export const startTestSetup = async () => {
     },
   ];
 
+  const claimer = {seed:"card insect figure furnace better miracle lend monitor call inner half top", address: "15B4rygvyb1BdA33AatuT7btLiZSUfcAS14X1SLrDfpq8Eou"};
+
   const nodes = [
     {
       name: "alice",
@@ -135,6 +137,19 @@ export const startTestSetup = async () => {
       initialized: false,
     },
   ];
+
+  // Send funds to reward claimer:
+  console.log(`{TestSetup::RewardClaimer} Sending funds to reward claimer address: ${claimer.address}`);
+  const claimerTransfer = api.tx.balances.transfer(
+    claimer.address,
+    "12345678912345"
+  );
+  try {
+    const hash = await claimerTransfer.signAndSend(keyring.addFromUri("//Alice"));
+  } catch {
+    console.log(`{TestSetup::Reward::${claimer.address}} transfer tx failed...`);
+  }
+  await sleep(3000);
 
   // For each nominator:
   // - Transfer some balance into the stash account from Alice

--- a/src/scorekeeper.ts
+++ b/src/scorekeeper.ts
@@ -185,7 +185,13 @@ export default class ScoreKeeper {
 
   // Adds a claimer from the config
   async addClaimer(claimerCfg: ClaimerConfig): Promise<boolean> {
-    const claimer = new Claimer(this.handler, this.db, claimerCfg, this.config.global.networkPrefix, this.bot);
+    const claimer = new Claimer(
+      this.handler,
+      this.db,
+      claimerCfg,
+      this.config.global.networkPrefix,
+      this.bot
+    );
     this.claimer = claimer;
     return true;
   }

--- a/src/scorekeeper.ts
+++ b/src/scorekeeper.ts
@@ -20,7 +20,11 @@ import logger from "./logger";
 import Nominator from "./nominator";
 import { CandidateData, Stash } from "./types";
 import { formatAddress, getNow, sleep, toDecimals } from "./util";
-import { startCandidateChainDataJob, startExecutionJob, startValidatityJob } from "./cron";
+import {
+  startCandidateChainDataJob,
+  startExecutionJob,
+  startValidatityJob,
+} from "./cron";
 
 type NominatorGroup = NominatorConfig[];
 
@@ -266,7 +270,13 @@ export default class ScoreKeeper {
     });
 
     startValidatityJob(this.config, this.db, this.constraints);
-    startCandidateChainDataJob(this.config, this.handler, this.db, this.constraints, this.chaindata);
+    startCandidateChainDataJob(
+      this.config,
+      this.handler,
+      this.db,
+      this.constraints,
+      this.chaindata
+    );
     startExecutionJob(
       this.handler,
       this.nominatorGroups,

--- a/src/scorekeeper.ts
+++ b/src/scorekeeper.ts
@@ -20,7 +20,7 @@ import logger from "./logger";
 import Nominator from "./nominator";
 import { CandidateData, Stash } from "./types";
 import { formatAddress, getNow, sleep, toDecimals } from "./util";
-import { startExecutionJob, startValidatityJob } from "./cron";
+import { startCandidateChainDataJob, startExecutionJob, startValidatityJob } from "./cron";
 
 type NominatorGroup = NominatorConfig[];
 
@@ -266,6 +266,7 @@ export default class ScoreKeeper {
     });
 
     startValidatityJob(this.config, this.db, this.constraints);
+    startCandidateChainDataJob(this.config, this.handler, this.db, this.constraints, this.chaindata);
     startExecutionJob(
       this.handler,
       this.nominatorGroups,

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ const API = {
   GetNodes: "/nodes",
   GetNominators: "/nominators",
   GetNominations: "/nominations",
+  GetBotClaimEvents: "/claims",
   Health: "/healthcheck",
   Invalid: "/invalid",
   ValidCandidates: "/valid",
@@ -64,6 +65,11 @@ export default class Server {
 
     router.get(API.GetNominations, async (ctx) => {
       const allNominations = await this.db.allNominations();
+      ctx.body = allNominations;
+    });
+
+    router.get(API.GetBotClaimEvents, async (ctx) => {
+      const allNominations = await this.db.getBotClaimEvents();
       ctx.body = allNominations;
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,15 @@ export type NominatorConfig = {
   proxyFor?: string;
 };
 
+export type ClaimerConfig = {
+  seed:string;
+}
+
+export type EraReward = {
+  stash: string;
+  era: number;
+}
+
 export type BooleanResult = [boolean | null, string | null];
 export type NumberResult = [number | null, string | null];
 export type StringResult = [string | null, string | null];

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,13 +9,13 @@ export type NominatorConfig = {
 };
 
 export type ClaimerConfig = {
-  seed:string;
-}
+  seed: string;
+};
 
 export type EraReward = {
   stash: string;
   era: number;
-}
+};
 
 export type BooleanResult = [boolean | null, string | null];
 export type NumberResult = [number | null, string | null];

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,4 +39,5 @@ export type CandidateData = {
   kusamaStash: string;
   skipSelfStake: boolean;
   bio: string;
+  unclaimedEras: [number];
 };


### PR DESCRIPTION
Adds the following additions:

- Validators must not have unclaimed rewards greater than 4 days (4 eras for Polkadot, or 16 eras for Kusama), otherwise they are invalid and not considered for nominations
- If Validators have unclaimed rewards greater than 8 days, they will get a fault.
- Unclaimed rewards are now kept track of in the db
- At the end of a round, instead of checking for the validator being offline, it is checked that they do not have too much downtime.
- Adds in a 'CandidateChainData' cron job, which runs every 5 minutes and sets on chain information to the db.
- Makes the Polkadot candidate invalid if their kusama validator is also invalid
- Adds a reward claimer that will try and claim rewards from 84-64 eras ago.
    - If these rewards need to be claimed, validators lose some ranks
- Adds db events for claims
- Adds `/claims` endpoint for querying those claims