### PR TITLE
Add Era Points Endpoint

### DIFF
--- a/charts/otv-backend/Chart.yaml
+++ b/charts/otv-backend/Chart.yaml
@@ -1,4 +1,4 @@
 description: 1K Validators Backend
 name: otv-backend
-version: v2.2.83
+version: v2.2.84
 apiVersion: v2

--- a/helmfile.d/10-otv-backend.yaml
+++ b/helmfile.d/10-otv-backend.yaml
@@ -11,7 +11,7 @@ releases:
     namespace: kusama
     {{ if eq .Environment.Name "production" }}
     chart: w3f/otv-backend
-    version: v2.2.83
+    version: v2.2.84
     {{ else }}
     chart: ../charts/otv-backend
     {{ end }}
@@ -23,7 +23,7 @@ releases:
     namespace: polkadot
     {{ if eq .Environment.Name "production" }}
     chart: w3f/otv-backend
-    version: v2.2.83
+    version: v2.2.84
     {{ else }}
     chart: ../charts/otv-backend
     {{ end }} 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "1k-validators-be",
-  "version": "2.2.83",
+  "version": "2.2.84",
   "description": "Services for running the Thousand Validator Program.",
   "main": "index.js",
   "scripts": {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1040,7 +1040,7 @@ export default class Db {
         },
         {
           totalEraPoints: total,
-          validatorsEraPoitns: validators,
+          validatorsEraPoints: validators,
         }
       )
       .exec();
@@ -1050,6 +1050,10 @@ export default class Db {
     return await this.totalEraPointsModel.findOne({
       era: era,
     });
+  }
+
+  async getLastTotalEraPoints(): Promise<any> {
+    return await this.totalEraPointsModel.find({}).sort("-era").limit(1);
   }
 
   // Gets the era points for a validator for the past 84 eras from a current era

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import { startClearAccumulatedOfflineTimeJob, startMonitorJob } from "./cron";
 
 const isCI = process.env.CI;
 
-const version = "v2.2.83";
+const version = "v2.2.84";
 
 const catchAndQuit = async (fn: any) => {
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ const API = {
   Health: "/healthcheck",
   Invalid: "/invalid",
   ValidCandidates: "/valid",
+  EraPoints: "/erapoints/:stash",
 };
 
 export default class Server {
@@ -87,6 +88,17 @@ export default class Server {
     router.get(API.ValidCandidates, (ctx) => {
       const valid = scoreKeeper.constraints.validCandidateCache;
       ctx.body = valid;
+    });
+
+    router.get(API.EraPoints, async (ctx) => {
+      const { stash } = ctx.params;
+      const latestEra = (await this.db.getLastTotalEraPoints())[0].era;
+      console.log(latestEra);
+      const eraPoints = await this.db.getHistoryDepthEraPoints(
+        stash,
+        latestEra
+      );
+      ctx.body = eraPoints;
     });
 
     this.app.use(router.routes());


### PR DESCRIPTION
Adds an endpoint `/erapoints/:address`, which returns the last 84 eras worth of era points information for the validator.


closes #852