### PR TITLE
Fix mismatching validator name

### DIFF
--- a/helmfile.d/config/kusama/otv-backend.yaml.gotmpl
+++ b/helmfile.d/config/kusama/otv-backend.yaml.gotmpl
@@ -2484,7 +2484,7 @@ config: |
               "riotHandle": "@ksmoon:matrix.org"
           },
           {
-              "name": "🍁 HIGH/STAKE 🥩 | HEL2-KSM",
+              "name": "🍁 HIGH/STAKE 🥩 | ZRH1-KSM",
               "stash": "HQuPha82sRy91zZn73XRGJVV3ernBh5HZKftUcoDT8CSUwK",
               "riotHandle": "@highstake:matrix.org"
           },


### PR DESCRIPTION
Looks like the telemetry name changed to ZRH1 also the location is updated.