### PR TITLE
Fix wrong polkadot validator address for migrated validator

### DIFF
--- a/helmfile.d/config/polkadot/otv-backend.yaml.gotmpl
+++ b/helmfile.d/config/polkadot/otv-backend.yaml.gotmpl
@@ -853,7 +853,7 @@ config: |
         },
         {
           "name": "JUST JONAS/1",
-          "stash": "14NRcqdfKyv9txzCoinHNExtUzTyYQvnbirqqRVzReCAcGHr",
+          "stash": "153Fz22gxQP8HM8RbnvEt9XWsXu9nR8jxZC2MbQFmuKhN62f",
           "kusamaStash": "DPdkDRzUV56F5R8fNjZwFx2Uctn173c1UJJXjxQMVMZuCqS",
           "riotHandle": "@amj.stake:matrix.org",
           "skipSelfStake": true


### PR DESCRIPTION
The validator owner mentioned that the polkadot stash address is wrong. We might want to migrate the DB entry to that new address too.