### PR TITLE
Remove MantraDAO

### DIFF
--- a/helmfile.d/config/polkadot/otv-backend-prod.yaml.gotmpl
+++ b/helmfile.d/config/polkadot/otv-backend-prod.yaml.gotmpl
@@ -119,12 +119,6 @@ config: |
           "riotHandle": "@hodl_farm:matrix.org"
         },
         {
-          "name": "MantraDAO",
-          "stash": "14B2ArWoQKrZy6mcHF6St6GKajTX1WzUAqpQhiVs7Bkq8n7W",
-          "kusamaStash": "HhZkxUEceUTr4FYNUAZECizfd5QLVKMdfZAL1eY3xPAPmwA",
-          "riotHandle": "@jp_mullin:matrix.org"
-        },
-        {
           "name": "◎◉ finalbits",
           "stash": "14NGUTHPtUvjbJttSF4qYmX8mUKk75UweWsL3GZyHw4ue2pv",
           "kusamaStash": "DmTzGAndAch8kXngopH69bcQCjYTukbp5Vh9SpJyiGfouwp",


### PR DESCRIPTION
MantraDAO shows' as Valid in Polkadot even though it has not been a Valid on Kusama for 10 months.
Kusama 1KV shows 
Name:			MANTRADAO
Discovered At		1 years ago
Nominated At		4 Jun 2021
Rank			0
Updated At		false
Version			0.8.26-1-803da90f7-x86_64-linux-gnu
Invalidity Reasons	MANTRADAO is not on the latest client version
			        MANTRADAO does not have a validate intention.

Polkadot MantraDAO
https://github.com/w3f/1k-validators-be/blob/master/helmfile.d/config/polkadot/otv-backend.yaml.gotmpl
          "name": "MantraDAO",
          "stash": "14B2ArWoQKrZy6mcHF6St6GKajTX1WzUAqpQhiVs7Bkq8n7W",
          "kusamaStash": "HhZkxUEceUTr4FYNUAZECizfd5QLVKMdfZAL1eY3xPAPmwA",
          "riotHandle": "@jp_mullin:matrix.org"

Kusama MantraDAO
https://github.com/w3f/1k-validators-be/blob/master/helmfile.d/config/kusama/otv-backend.yaml.gotmpl
              "name": "MANTRADAO",
              "stash": "FgLXQHptvj9PEmkJxvTEAeD7SbpD9rZPGPQ3U7WaEqNDMCD",
              "riotHandle": "@jp_mullin:matrix.org"

MantraDAO stash does not match between Polkadot and Kusama

1. There is no Validator nodes with Stash: "HhZkxUEceUTr4FYNUAZECizfd5QLVKMdfZAL1eY3xPAPmwA" in Kusama
2. Telemetry is case sensitive and in Kusama there is no MANTRADAO node but there is MantraDAO
3. Polkadot MANTRADAO is old version 0.9.16 which should be updated 
4. MANTRADAO has few nodes with old version 0.9.16 which should be updated 
5. Polkadot MantraDAO was nominated last time by 1KV on 15 Feb 2022 but Kusama node has not been valid since