### PR TITLE
Removing additional X's from validator name

### DIFF
--- a/helmfile.d/config/polkadot/otv-backend-prod.yaml.gotmpl
+++ b/helmfile.d/config/polkadot/otv-backend-prod.yaml.gotmpl
@@ -580,7 +580,7 @@ config: |
         {
           "name": "Dox-DOT-validator",
           "stash": "14hM4oLJCK6wtS7gNfwTDhthRjy5QJ1t3NAcoPjEepo9AH67",
-          "kusamaStash": "ExWRdMwU8JLrfaQvGJ6TxhtTbxjCtcLhbVQoSXLANywK6uo",
+          "kusamaStash": "DtrDM8ZZpBhTSwptMCgYEzJqbPUFArScxikZfbd9tHA47PZ",
           "riotHandle": "@paradoxxx:matrix.org"
         },
         {

--- a/helmfile.d/config/polkadot/otv-backend-prod.yaml.gotmpl
+++ b/helmfile.d/config/polkadot/otv-backend-prod.yaml.gotmpl
@@ -578,7 +578,7 @@ config: |
           "riotHandle": "@kwunyeung:matrix.org"
         },
         {
-          "name": "Doxxx-DOT-validator",
+          "name": "Dox-DOT-validator",
           "stash": "14hM4oLJCK6wtS7gNfwTDhthRjy5QJ1t3NAcoPjEepo9AH67",
           "kusamaStash": "ExWRdMwU8JLrfaQvGJ6TxhtTbxjCtcLhbVQoSXLANywK6uo",
           "riotHandle": "@paradoxxx:matrix.org"


### PR DESCRIPTION
From a public image standpoint I would like to remove the additional X's from my validator's telemetry name.