### PR TITLE
Update otv-backend-prod.yaml.gotmpl

### DIFF
--- a/helmfile.d/config/kusama/otv-backend-prod.yaml.gotmpl
+++ b/helmfile.d/config/kusama/otv-backend-prod.yaml.gotmpl
@@ -2843,7 +2843,7 @@ config: |
               "riotHandle": "@andreesken:matrix.org"
           },
           {
-              "name": "Blockseeker.io",
+              "name": "blockseeker_io",
               "stash": "HPuireorhWdSCQg5dG1zeGk7XCuAfkb21BtDyLqRuN62k67",
               "riotHandle": "@blockseeker.io:matrix.org"
           },


### PR DESCRIPTION
`name` was matching identity rather than node name for telemetry. `polkadot` daemon does not accept `.` in name therefore I would like the name here to match what is specified in the telemetry which is `blockseeker_io`.

Apparently  uptime, online status and client version are not being tracked.

`discoveredAt: 0` and `ONLINE` state is always `false` therefore my node will never be eligible for being active/nominated.

I'm hoping this change will make it eligible.