### PR TITLE
🚑️ ReleaseMonitor - fix version detection

### DIFF
--- a/packages/core/src/monitor.ts
+++ b/packages/core/src/monitor.ts
@@ -49,7 +49,7 @@ export default class Monitor {
     }
 
     this.latestTaggedRelease = {
-      name: tag_name.split(`-`)[0],
+      name: tag_name.split(`-rc`)[0],
       publishedAt,
     };
 

--- a/packages/worker/src/jobs/ReleaseMonitorJob.ts
+++ b/packages/worker/src/jobs/ReleaseMonitorJob.ts
@@ -29,7 +29,7 @@ export const getLatestTaggedRelease = async () => {
     logger.info("No new release found", monitorLabel);
   } else {
     latestTaggedRelease = {
-      name: tag_name.split(`-`)[0],
+      name: tag_name.split(`-rc`)[0],
       publishedAt,
     };
   }


### PR DESCRIPTION
critical hotfix release v0.9.39-1 got released 2+ days ago and non updated v0.9.39 clients are still nominated by 1KV causing massive trouble due to disputing

