### PR TITLE
Fix NOVASAMA validator name

### DIFF
--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -1340,7 +1340,7 @@
       "riotHandle": "@stakehulk:matrix.org"
     },
     {
-      "name": "\uD83C\uDF0CNOVASAMA\uD83C\uDF0C/NASH   ex NOVASAMA_TECHNOLOGIES/VAL_1",
+      "name": "\uD83C\uDF0CNOVASAMA\uD83C\uDF0C/NASH",
       "stash": "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
       "kusamaStash": "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
       "riotHandle": "@solocrack:matrix.org"


### PR DESCRIPTION
This PR corrects an issue with Novasama's validator name for Polkadot. 
In the application form, the name was occasionally incorrect.