### PR TITLE
Remove duplicate havik candidate

### DIFF
--- a/candidates/kusama.json
+++ b/candidates/kusama.json
@@ -3243,11 +3243,6 @@
       "riotHandle": "@shawneng:matrix.org "
     },
     {
-      "name": "havik",
-      "stash": "FQ4fiDSgVg556BoLYNjqM66qVei9ATbwNSuYbHHDvSF8Hb3",
-      "riotHandle": "@havik:matrix.org"
-    },
-    {
       "name": "blockops-validator-0",
       "stash": "HLsQZEMMN2cDN1cZBgMc48E2v1XergevtDZQ6Nueue7x2F9",
       "riotHandle": "@haroldsphinx:matrix.org"


### PR DESCRIPTION
Changing the node name and re-applying to the program resulted in having two candidates with the same stash.

This PR removes the old one "havik" leaving the new one "havik-kusama"