### PR TITLE
Remove leading space from validator name

### DIFF
--- a/candidates/kusama.json
+++ b/candidates/kusama.json
@@ -3654,7 +3654,7 @@
       "riotHandle": "@wdmaster:matrix.org"
     },
     {
-      "name": " validorange-ksm1",
+      "name": "validorange-ksm1",
       "stash": "J47U9wGuwzccFPoz8bnMTKJt7WGpPp8ZNgvtXFDL9PHwpCt",
       "riotHandle": "@validorange:matrix.org"
     },


### PR DESCRIPTION
This is my validator, I must have added the space by accident when I submitted the application. It was suggested at https://matrix.to/#/!LhjZccBOqFNYKLdmbb:polkadot.builders/$169454950170669iOWYF:matrix.org?via=parity.io&via=matrix.org&via=corepaper.org that I submit a PR to correct it.