### PR TITLE
rename kusama xi under rotko networks and good intention

### DIFF
--- a/candidates/kusama.json
+++ b/candidates/kusama.json
@@ -148,7 +148,10 @@
     {
       "name": "KUSAMAPROPHET",
       "stash": "HKnRS3RryHjzTHGu42u6BtVp2cNuYoRVnrUJGeRAKqagsKY",
-      "riotHandle": ["@fbranciard:matrix.org", "@vladost:matrix.org"]
+      "riotHandle": [
+        "@fbranciard:matrix.org",
+        "@vladost:matrix.org"
+      ]
     },
     {
       "name": "Genesis-Node",
@@ -558,7 +561,10 @@
     {
       "name": "PureStake_Kusama_03",
       "stash": "DVw4Zkfva2MPibAsr8vgoha1T2ow8zreoTWGyBDioQBdfMM",
-      "riotHandle": ["@artk:matrix.org", "@mitchell-g:matrix.org"]
+      "riotHandle": [
+        "@artk:matrix.org",
+        "@mitchell-g:matrix.org"
+      ]
     },
     {
       "name": "🎠 Forbole 🇭🇰",
@@ -593,7 +599,10 @@
     {
       "name": "Dionysus-sv-validator-0",
       "stash": "FWz717J6ATaYSNy2tRHAskEC9SP4uKHNJYC9mvfvimkB8GT",
-      "riotHandle": ["@syed:web3.foundation", "@remohammdi:matrix.org"]
+      "riotHandle": [
+        "@syed:web3.foundation",
+        "@remohammdi:matrix.org"
+      ]
     },
     {
       "name": "CoinStudio",
@@ -678,7 +687,11 @@
     {
       "name": "birb-01",
       "stash": "GZvxvwKGaZyq21BHnrUpdQkpcF4jrCsi23d3c6dvsmp6BF8",
-      "riotHandle": ["@azk:fairydust.space", "@valka:fairydust.space", "@s3krit:fairydust.space"]
+      "riotHandle": [
+        "@azk:fairydust.space",
+        "@valka:fairydust.space",
+        "@s3krit:fairydust.space"
+      ]
     },
     {
       "name": "Eat Pray Validate 1 🍴🙏🖥 ",
@@ -906,7 +919,7 @@
       "riotHandle": "@robert:web3.foundation"
     },
     {
-      "name": "Kusama XI Validator",
+      "name": "Rotko Networks - ksm01 Validator",
       "stash": "ESSZefozpZYVLbLF1vaGtabthQYg8PVXiTytVm6YiiwAnee",
       "riotHandle": "@hitchhooker:matrix.org"
     },
@@ -1013,7 +1026,10 @@
     {
       "name": "postchain_io",
       "stash": "EHs5p1TR3SpQXvqAUq7pL4qKWRVNmrvtCT4izncvnk6Kh5W",
-      "riotHandle": ["@postchain_p:matrix.org", "@postchain_d:matrix.org"]
+      "riotHandle": [
+        "@postchain_p:matrix.org",
+        "@postchain_d:matrix.org"
+      ]
     },
     {
       "name": "Uno Staking",
@@ -1677,7 +1693,7 @@
       "skipSelfStake": true
     },
     {
-      "name": "Kusama XI Validator 2",
+      "name": "Rotko Networks - ksm02 Validator",
       "stash": "DKKax6uZkiNPfd2ATd8cJhyi3c1KZD24VDdoWG9CfTmwgSp",
       "riotHandle": "@hitchhooker:matrix.org"
     },
@@ -2040,7 +2056,10 @@
     {
       "name": "ForklessNation ॐ 0",
       "stash": "H2hR9442doETZ5eRFaP2JHKZJKyLUzSH4xbJ56FC17tPuEC",
-      "riotHandle": ["@synapticon:matrix.org", "@Darkstar/forklessnation:matrix.org"]
+      "riotHandle": [
+        "@synapticon:matrix.org",
+        "@Darkstar/forklessnation:matrix.org"
+      ]
     },
     {
       "name": "VLADIMIR2",
@@ -2205,7 +2224,10 @@
     {
       "name": "Texas Blockchain Node 2",
       "stash": "CwUhDjLKnvtjLM5Caxh4KFEeH5B4LezYM297TxnS7xQw7aB",
-      "riotHandle":  ["@aharris:austin-harris.com", "@srivish:matrix.org"]
+      "riotHandle": [
+        "@aharris:austin-harris.com",
+        "@srivish:matrix.org"
+      ]
     },
     {
       "name": "SONYA-STAKING2",
@@ -3255,7 +3277,10 @@
     {
       "name": "enby-collective-dominique-1",
       "stash": "GZeiCMQMMU3yPV2GMwZoiNvC1cqMWx7HTSBXeJsd27b3Wnj",
-      "riotHandle": ["@dominique:parity.io", "@enby:matrix.org"]
+      "riotHandle": [
+        "@dominique:parity.io",
+        "@enby:matrix.org"
+      ]
     },
     {
       "name": "slither_77",
@@ -3466,7 +3491,10 @@
     {
       "name": "ForklessNation2",
       "stash": "FyRsWF9bSQkK8TiJ1BdPoKtwvCwtZG7BYPoJFmZHVXnMDit",
-      "riotHandle": ["@synapticon:matrix.org", "@Darkstar/forklessnation:matrix.org"]
+      "riotHandle": [
+        "@synapticon:matrix.org",
+        "@Darkstar/forklessnation:matrix.org"
+      ]
     },
     {
       "name": "cryhel",

--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -10,7 +10,6 @@
       "name": "🔒stateless_money🔒 / 1",
       "stash": "14Vh8S1DzzycngbAB9vqEgPFR9JpSvmF1ezihTUES1EaHAV",
       "kusamaStash": "HZvvFHgPdhDr6DHN43xT1sP5fDyzLDFv5t5xwmXBrm6dusm",
-      "riotHandle": "@aaronschwarz:matrix.org"
     },
     {
       "name": "KeepNode-Carbon",
@@ -28,7 +27,11 @@
       "name": "Genesis Lab",
       "stash": "13K6QTYBPMUFTbhZzqToKcfCiWbt4wDPHr3rUPyUessiPR61",
       "kusamaStash": "DuRV4MSm54UoX3MpFe3P7rxjBFLfnKRThxG66s4n3yF8qbJ",
-      "riotHandle": ["@i7495:matrix.org", "@black_rock:matrix.org", "@pvdmitriy:matrix.org"]
+      "riotHandle": [
+        "@i7495:matrix.org",
+        "@black_rock:matrix.org",
+        "@pvdmitriy:matrix.org"
+      ]
     },
     {
       "name": "🍒 RYABINA 🍒 6",
@@ -46,7 +49,10 @@
       "name": "luguslabs-validator-1",
       "stash": "16aFDVsp6zd6VxUSgd34es3r23nWRkoj3NdLTS5Fk1Ez9MU1",
       "kusamaStash": "HKnRS3RryHjzTHGu42u6BtVp2cNuYoRVnrUJGeRAKqagsKY",
-      "riotHandle": ["@fbranciard:matrix.org", "@vladost:matrix.org"]
+      "riotHandle": [
+        "@fbranciard:matrix.org",
+        "@vladost:matrix.org"
+      ]
     },
     {
       "name": "🐑 Hodl_dot_farm A 🐑",
@@ -322,7 +328,10 @@
       "name": "PureStake_Polkadot_01",
       "stash": "14yx4vPAACZRhoDQm1dyvXD3QdRQyCRRCe5tj1zPomhhS29a",
       "kusamaStash": "DVw4Zkfva2MPibAsr8vgoha1T2ow8zreoTWGyBDioQBdfMM",
-      "riotHandle": ["@artk:matrix.org", "@mitchell-g:matrix.org"]
+      "riotHandle": [
+        "@artk:matrix.org",
+        "@mitchell-g:matrix.org"
+      ]
     },
     {
       "name": "Northwoods-C",
@@ -1035,7 +1044,10 @@
       "name": "9Stake",
       "stash": "1x9GAG2hXoMt3i7jL7vTZLpdhNGyjffgQUwe8GU9HhhH62e",
       "kusamaStash": "CyzTh1chfwDa5GuBDfE3BC7e1H7Jnvoz21gf79ckeMJ7xeg",
-      "riotHandle": ["@9stake.9gag:matrix.org" , "@derek___c:matrix.org"]
+      "riotHandle": [
+        "@9stake.9gag:matrix.org",
+        "@derek___c:matrix.org"
+      ]
     },
     {
       "name": "BestValidator-polkadot1",
@@ -1118,7 +1130,10 @@
       "name": "Munich | validierung_cc 🇩🇪",
       "stash": "15x643ScnbVQM3zGcyRw3qVtaCoddmAfDv5LZVfU8fNxkVaR",
       "kusamaStash": "JHamburgTPv9fRKwTPeBEjyVHmbQK2ayRBpBujb4rx2sHzJ",
-      "riotHandle": ["@kev.funke:matrix.org", "@bkzland:matrix.org"],
+      "riotHandle": [
+        "@kev.funke:matrix.org",
+        "@bkzland:matrix.org"
+      ],
       "skipSelfStake": true
     },
     {
@@ -1465,7 +1480,8 @@
       "name": "Rotko Networks - dot01 Validator",
       "stash": "1ArdZJtNUrZsfidfn1t69xHaSWwzf6PQNdLEUpcnVmbkZc5",
       "kusamaStash": "DKKax6uZkiNPfd2ATd8cJhyi3c1KZD24VDdoWG9CfTmwgSp",
-      "riotHandle": "@hitchhooker:matrix.org"
+      "riotHandle": "@hitchhooker:matrix.org",
+      "skipSelfStake": true
     },
     {
       "name": "havik-polkadot",


### PR DESCRIPTION
PR to rename telemtry name and reconsider good intention of Rotko Networks

1. **Relaychain Bootnodes**:
   - I have been running relaychain bootnodes for over a month. Check out the [GitHub Pull Request](https://github.com/paritytech/polkadot-sdk/pull/1185) for more details.

2. **Infrastructure Automation**:
   - For infrastructure automation tasks, you can refer to the [repository on GitHub](https://github.com/rotkonetworks/unlabored).
   - Most extensive open sourced automation infra for proxmox in the ecosystem(~30 rolebooks) 

3. **Promox Monitoring Dashboard**:
   - Dashboard: [Eupnea](https://eupnea.rotko.net/)
   - Source Code: [Unlabored Dashboard on GitHub](https://github.com/rotkonetworks/unlabored-dashboard)

4. **Hardware Investments**:
   - Details about the hardware setup can be found [here](https://rotko.net/docs/rack.html).
   - Investments:
     - Initial cost: Approximately $10,000
     - Recurring costs: ~$300 monthly for 10U slots and ~$600 for 200/200 mbits international bandwidth.

5. **Blog**:
   - Running [blog](https://kusamaxi.com/posts/) with tips and articles for community.

I genuinely hope you'll reconsider the good will application. If not, any feedback about what might be lacking or needs improvement would be greatly appreciated. Thank you.