### PR TITLE
updated name & stash of decentraDOT 1

### DIFF
--- a/candidates/kusama.json
+++ b/candidates/kusama.json
@@ -1616,8 +1616,8 @@
       "riotHandle": "@cosmotronv:matrix.org"
     },
     {
-      "name": "decentraDOT",
-      "stash": "GRSWBC1kCuNVp8KTgGyK7Bo3bP7CdLDPwfnx2L5JJLQ41Qj",
+      "name": "decentraDOT3",
+      "stash": "HqF6t7B84v2XTbAC4VZmjsyQhvRUJrcCdUPAYVCpYru32SU",
       "riotHandle": "@arthurhoeke:matrix.org"
     },
     {


### PR DESCRIPTION
Our first validator has become independent, we'd like to change the stash account and update telemetry name.
Can our rank be transferred over?
Thank you