### PR TITLE
Helm: Parameterize Ingress' annotations

### DIFF
--- a/charts/otv-backend/templates/ingress.yaml
+++ b/charts/otv-backend/templates/ingress.yaml
@@ -2,22 +2,17 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}
+  {{- if .Values.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    {{ if .Values.certificate.enabled }}
-    cert-manager.io/cluster-issuer: letsencrypt
-    {{ end }}
-    nginx.ingress.kubernetes.io/server-snippet: |
-      location /metrics {
-        deny all;
-      }
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  {{- end }}
 spec:
   tls:
   - hosts:
-      - {{ .Values.domain }}
+      - {{ .Values.ingress.domain }}
     secretName: {{ include "otv-backend.tls-secret-name" . }}
   rules:
-  - host: {{ .Values.domain }}
+  - host: {{ .Values.ingress.domain }}
     http:
       paths:
       - path: /

--- a/charts/otv-backend/values.yaml
+++ b/charts/otv-backend/values.yaml
@@ -4,7 +4,17 @@ image:
   repo: web3f/otv-backend
   #tag: latest
 
-domain: otv.w3f.community
+ingress:
+  domain: otv.w3f.community
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location /metrics {
+        deny all;
+      }
+    cert-manager.io/cluster-issuer: letsencrypt
+  certificate:
+    enabled: true
 
 dataPath: "/data"
 backendPort: 3300
@@ -17,9 +27,6 @@ resources:
   requests:
     cpu: 300m
     memory: 400Mi
-
-certificate:
-  enabled: true
 
 secret: |
   {

--- a/helmfile.d/config/kusama/otv-backend-ci.yaml.gotmpl
+++ b/helmfile.d/config/kusama/otv-backend-ci.yaml.gotmpl
@@ -1,4 +1,5 @@
-domain: kusama.w3f.community
+ingress:
+  domain: kusama.w3f.community
 
 resources:
   limits:

--- a/helmfile.d/config/kusama/otv-backend-local.yaml.gotmpl
+++ b/helmfile.d/config/kusama/otv-backend-local.yaml.gotmpl
@@ -1,4 +1,5 @@
-domain: kusama.w3f.community
+ingress:
+  domain: kusama.w3f.community
 
 resources:
   limits:

--- a/helmfile.d/config/polkadot/otv-backend-ci.yaml.gotmpl
+++ b/helmfile.d/config/polkadot/otv-backend-ci.yaml.gotmpl
@@ -1,4 +1,5 @@
-domain: polkadot.w3f.community
+ingress:
+  domain: polkadot.w3f.community
 
 resources:
   limits:

--- a/helmfile.d/config/polkadot/otv-backend-local.yaml.gotmpl
+++ b/helmfile.d/config/polkadot/otv-backend-local.yaml.gotmpl
@@ -1,4 +1,5 @@
-domain: polkadot.w3f.community
+ingress:
+  domain: polkadot.w3f.community
 
 resources:
   limits:


### PR DESCRIPTION
The PR helps to parameterize ingress annotations for people who want to change them in their environment accordingly. The changes have been applied to helmfiles and should not break the existing deployments.