### PR TITLE
update opengov scores

### DIFF
--- a/apps/1kv-backend/config/kusama-score.json
+++ b/apps/1kv-backend/config/kusama-score.json
@@ -15,6 +15,6 @@
   "democracy": "30",
   "nominations": "100",
   "delegations": "60",
-  "openGov": "100",
-  "openGovDelegation": "100"
+  "openGov": "0",
+  "openGovDelegation": "0"
 }

--- a/apps/1kv-backend/config/polkadot-score.json
+++ b/apps/1kv-backend/config/polkadot-score.json
@@ -15,6 +15,6 @@
   "democracy": "30",
   "nominations": "100",
   "delegations": "60",
-  "openGov": "100",
-  "openGovDelegation": "100"
+  "openGov": "0",
+  "openGovDelegation": "0"
 }


### PR DESCRIPTION
Adjusts open gov and opengov delegation score to 0 so it's less confusing (they're already not included in the total, although still show via the api)