### PR TITLE
add slotId and kyc fields to all candidates

### DIFF
--- a/candidates/kusama.json
+++ b/candidates/kusama.json
@@ -1,4145 +1,5795 @@
 {
   "candidates": [
     {
+      "slotId": 0,
       "name": "Blockshard",
       "stash": "Cp4U5UYg2FaVUpyEtQgfBm9aqge6EEPkJxEFVZFYy7L1AZF",
-      "riotHandle": "@marc1104:matrix.org"
+      "riotHandle": "@marc1104:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 1,
       "name": "🎠 Forbole GP01 🇭🇰",
       "stash": "D9rwRxuG8xm8TZf5tgkbPxhhTJK5frCJU9wvp59VRjcMkUf",
-      "riotHandle": "@kwunyeung:matrix.org"
+      "riotHandle": "@kwunyeung:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 2,
       "name": "🔱-Masternode24-🔱",
       "stash": "FyRaMYvPqpNGq6PFGCcUWcJJWKgEz29ZFbdsnoNAczC2wJZ",
-      "riotHandle": "@alexkidd:matrix.org"
+      "riotHandle": "@alexkidd:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 3,
       "name": "🔱-Masternode25-🔱",
       "stash": "FNztLLstrnThEEctuH2C9Kw1d73xVVxm2crji2mkb4ioXsn",
-      "riotHandle": "@alexkidd:matrix.org"
+      "riotHandle": "@alexkidd:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 4,
       "name": "Anonstake",
       "stash": "J4hAvZoHCviZSoPHoSwLida8cEkZR1NXJcGrcfx9saHTk7D",
-      "riotHandle": "@anon2020:matrix.org"
+      "riotHandle": "@anon2020:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 5,
       "name": "Indigo One",
       "stash": "EPhtbjecJ9P2SQEGEJ4XmFS4xN7JioBFarSrbqjhj8BuJ2v",
-      "riotHandle": "@shadewolf:matrix.org"
+      "riotHandle": "@shadewolf:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 6,
       "name": "KIRA Staking",
       "stash": "HhcrzHdB5iBx823XNfBUukjj4TUGzS9oXS8brwLm4ovMuVp",
-      "riotHandle": "@asmodat:matrix.org"
+      "riotHandle": "@asmodat:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 7,
       "name": "Staker Space [1]",
       "stash": "FcjmeNzPk3vgdENm1rHeiMCxFK96beUoi2kb59FmCoZtkGF",
-      "riotHandle": "@gnossienli:matrix.org"
+      "riotHandle": "@gnossienli:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 8,
       "name": "Genesis Lab",
       "stash": "DuRV4MSm54UoX3MpFe3P7rxjBFLfnKRThxG66s4n3yF8qbJ",
-      "riotHandle": "@i7495:matrix.org"
+      "riotHandle": "@i7495:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 9,
       "name": "🔒STATELESS_MONEY-2🔒",
       "stash": "HZvvFHgPdhDr6DHN43xT1sP5fDyzLDFv5t5xwmXBrm6dusm",
-      "riotHandle": "@aaronschwarz:matrix.org"
+      "riotHandle": "@aaronschwarz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 10,
       "name": "🔒STATELESS_MONEY-2🔒/1",
       "stash": "Cdaq3iUobZLYD2d8oqRQf1VKuRo6H64KsMBgJyxap4ZnARX",
-      "riotHandle": "@aaronschwarz:matrix.org"
+      "riotHandle": "@aaronschwarz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 11,
       "name": "WolfEdge-Capital",
       "stash": "EtJ4HxHYEDvYWRJAdmV4hYpTbGMJCmEgnLC8zAf6u5ZyT7C",
-      "riotHandle": "@mohakagr:matrix.org"
+      "riotHandle": "@mohakagr:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 12,
       "name": "🐑 Hodl_dot_farm C 🐑",
       "stash": "GrG7JZFyaN83UZ51Wv2nrHzwpKtphN6xL6rX2Dva5793KwY",
-      "riotHandle": "@hodl_farm:matrix.org"
+      "riotHandle": "@hodl_farm:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 13,
       "name": "Simply Staking",
       "stash": "DNDBcYD8zzqAoZEtgNzouVp2sVxsvqzD4UdB5WrAUwjqpL8",
-      "riotHandle": "@daniel-svc:matrix.org"
+      "riotHandle": "@daniel-svc:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 14,
       "name": "newton🇫🇷",
       "stash": "DxErsWqBducKTqxq7dwXKk2kevAzWEWaYJjwtwzqCu2r3F4",
-      "riotHandle": "@gauth8z:matrix.org"
+      "riotHandle": "@gauth8z:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 15,
       "name": "🥩 Staking4All 🥩",
       "stash": "GTUi6r2LEsf71zEQDnBvBvKskQcWvK66KRqcRbdmcczaadr",
-      "riotHandle": "@staking4all:matrix.org"
+      "riotHandle": "@staking4all:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 16,
       "name": "◎◉ finalbits",
       "stash": "DmTzGAndAch8kXngopH69bcQCjYTukbp5Vh9SpJyiGfouwp",
-      "riotHandle": "@arifk:matrix.org"
+      "riotHandle": "@arifk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 17,
       "name": "ryabinav1",
       "stash": "GxxV8DAcHCSzBbspu83AK9UoTYxzSQ6VVfdopjnkXfPtE8d",
-      "riotHandle": "@ryabina:matrix.org"
+      "riotHandle": "@ryabina:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 18,
       "name": "🚀 PolkaStats",
       "stash": "GTzRQPzkcuynHgkEHhsPBFpKdh4sAacVRsnd8vYfPpTMeEY",
-      "riotHandle": "@mariopino:matrix.org"
+      "riotHandle": "@mariopino:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 19,
       "name": "🚀 PolkaStats/2",
       "stash": "EPStAMtjApGg8Ap6xKe9gyuinjmetz1MNhzu1cPmLQkWKUA",
-      "riotHandle": "@mariopino:matrix.org"
+      "riotHandle": "@mariopino:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 20,
       "name": "Magnetis-Node",
       "stash": "G543pxmwKNAbW2WepZW7Ss9Wgx9wuDQWcPyhk4eEzpzcibG",
-      "riotHandle": "@tatan:matrix.org"
+      "riotHandle": "@tatan:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 21,
       "name": "MurterKosirina",
       "stash": "E84ypSizBDJDxwhtYy4Q4t5RKsy1DppPuU1AP47HVeKhXYt",
-      "riotHandle": "@kizos:matrix.org"
+      "riotHandle": "@kizos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 22,
       "name": "🐲 DragonStake 🐉",
       "stash": "DSpbbk6HKKyS78c4KDLSxCetqbwnsemv2iocVXwNe2FAvWC",
-      "riotHandle": "@derfredy:matrix.org"
+      "riotHandle": "@derfredy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 23,
       "name": "🐲 DragonStake 3 🐉",
       "stash": "J4XkgJjMP6c1pqneV5KogJvJLM1qReXP9SAMJt33prnDdwB",
-      "riotHandle": "@derfredy:matrix.org"
+      "riotHandle": "@derfredy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 24,
       "name": "KeepNode",
       "stash": "FDDy3cQa7JXiChYU2xq1B2WUUJBpZpZ51qn2tiN1DqDMEpS",
-      "riotHandle": "@Drun:matrix.org"
+      "riotHandle": "@Drun:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 25,
       "name": "⛓  Novy Validator ⛓ ",
       "stash": "Cs7UFcNBsBV4Y65GsM3bDzpvinMKFQZyt6x9TrhVhc8ps4E",
-      "riotHandle": "@novy4:matrix.org"
+      "riotHandle": "@novy4:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 26,
       "name": "stakethat",
       "stash": "DAUrb4UVvwpYxbx6jTVqMquCW2QuafKcFCkgEpnYBcbwaRQ",
-      "riotHandle": "@andreisid:matrix.org"
+      "riotHandle": "@andreisid:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 27,
       "name": "clockchain",
       "stash": "GHiteLMW6qa4s1MU4pUNvxu2vWEpPJwqEpn1SVJCzEBSE7Y",
-      "riotHandle": "@clockchain:matrix.org"
+      "riotHandle": "@clockchain:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 28,
       "name": "StakeTomato",
       "stash": "EkpjJUusZu4FZxzC1EyYxoyCxKVGKAd5aEygoF38tqSv3C3",
-      "riotHandle": "@ade007:matrix.org"
+      "riotHandle": "@ade007:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 29,
       "name": "KUSAMAPROPHET",
       "stash": "HKnRS3RryHjzTHGu42u6BtVp2cNuYoRVnrUJGeRAKqagsKY",
-      "riotHandle": ["@fbranciard:matrix.org", "@vladost:matrix.org"]
+      "riotHandle": ["@fbranciard:matrix.org", "@vladost:matrix.org"],
+      "kyc": false
     },
     {
+      "slotId": 30,
       "name": "Genesis-Node",
       "stash": "Cm6QfCvV3vud3X6Zfg3yMBEnG6JFNsn6EzcZv6UyqTefkR1",
-      "riotHandle": "@v0idum:matrix.org"
+      "riotHandle": "@v0idum:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 31,
       "name": "GontaValidator_1",
       "stash": "D3ii6afqaMSFvw8R2NExE1qGQ8EawDsXTduSVm9y51K3Jnb",
-      "riotHandle": "@GontaJones:matrix.org"
+      "riotHandle": "@GontaJones:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 32,
       "name": "thirdwave-network-validator",
       "stash": "FqFKeVrWbBDVBk8U9VvL8gSFwUm4nj9fEZmtQvmViZzLvnv",
-      "riotHandle": "@tomaszwaszczyk:matrix.org"
+      "riotHandle": "@tomaszwaszczyk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 33,
       "name": "Axia",
       "stash": "HnR4exC2rBF6MCGVQSH1tdf6UppPvnz8CLNSVCL3VPR4mzQ",
-      "riotHandle": "@axia_:matrix.org"
+      "riotHandle": "@axia_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 34,
       "name": "Axia-02",
       "stash": "CiXHzQXbuCbR4gQgs6BBnBKh61bub61tjgWnHVGEtbBAPPj",
-      "riotHandle": "@axia_:matrix.org"
+      "riotHandle": "@axia_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 35,
       "name": "King Kusama",
       "stash": "EDHmmQtv8jGf3PGrsSJC2Bm2YWsF6DWTdKyTtBifPRHQTna",
-      "riotHandle": "@king-kusama:matrix.org"
+      "riotHandle": "@king-kusama:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 36,
       "name": "King Kusama-2",
       "stash": "GNptL51p7T4WEyL7qaXxpbW2Zzj2RKwimg1er3xZ6nJyoDx",
-      "riotHandle": "@king-kusama:matrix.org"
+      "riotHandle": "@king-kusama:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 37,
       "name": "AGx1",
       "stash": "DVasGX5qBMrCwNM8SnLyFrRpeniAwAsWe2noN6jPdx1jjao",
-      "riotHandle": "@agx10000:matrix.org"
+      "riotHandle": "@agx10000:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 38,
       "name": "NeNa",
       "stash": "GhNL9Mi5KiL3Ge2jv4jUdncipZNnUFALbzmwg8QqwjxJxcp",
-      "riotHandle": "@nametaken:matrix.org"
+      "riotHandle": "@nametaken:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 39,
       "name": "BladeRunner",
       "stash": "CpYNXnYC1mPPRSXMHvm9EUuhEqHjvj6kCN4kshqMdEpPYSF",
-      "riotHandle": "@d3ckard:matrix.org"
+      "riotHandle": "@d3ckard:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 40,
       "name": "Saxemberg3",
       "stash": "Dfg9gbTwG6aghwLYTfYoV4dXyhCRBLbRyFwENADHmg4zfDF",
-      "riotHandle": "@s_saxemberg:matrix.org"
+      "riotHandle": "@s_saxemberg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 41,
       "name": "tsuki-validator-0",
       "stash": "D3GpUSsNEnabe5mX8bCkq8Nnc9FVsZgb9nBbTjBq8t52GBg",
-      "riotHandle": "@nasamura:matrix.org"
+      "riotHandle": "@nasamura:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 42,
       "name": "Melange",
       "stash": "EAhgtgo4qb6tbh3VwrPEgxne9qkwiqg5SzNHTmbqyoVyHk5",
-      "riotHandle": "@palace:tzchat.org"
+      "riotHandle": "@palace:tzchat.org",
+      "kyc": false
     },
     {
+      "slotId": 43,
       "name": "PDP_Validator",
       "stash": "J7MmkYX4dJzUbNnU9ccemPFbxtsyaSgFVwAGMxx8k9Lf5cu",
-      "riotHandle": "@paveldp:matrix.org"
+      "riotHandle": "@paveldp:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 44,
       "name": "StakedTech",
       "stash": "FFRsm3haD645qfSVE1zfywYURWQ6z7YUAD4nad6Zw6qVxDk",
-      "riotHandle": "@veddoo:matrix.org"
+      "riotHandle": "@veddoo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 45,
       "name": "lab-node-cp1q",
       "stash": "DY3hczPcJjHXScXkKwJZ7vgqTE4bZaCUa56XsAQH8gDzB7x",
-      "riotHandle": "@kogeler:matrix.org"
+      "riotHandle": "@kogeler:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 46,
       "name": "node_vw7pkg",
       "stash": "DayVh23V32nFhvm2WojKx2bYZF1CirRgW2Jti9TXN9zaiH5",
-      "riotHandle": "@day7:matrix.org"
+      "riotHandle": "@day7:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 47,
       "name": "rocknode",
       "stash": "EUviNVqJCsvWaKnSHdqyVQQaJB5zQv6szGKUdPKK1dsBvcn",
-      "riotHandle": "@rocknode:matrix.org"
+      "riotHandle": "@rocknode:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 48,
       "name": "🏢 Ministry Of Blocks 🏢",
       "stash": "D2r9AudNkHHpKfGtS5rpVHkchBoBhRsR6TmNcTuU4yiTp6w",
-      "riotHandle": "@slavamo:matrix.org"
+      "riotHandle": "@slavamo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 49,
       "name": "ANGL",
       "stash": "Ef1zUqDDDNME7FwfD2AXKUD5NTixnrmwaF8cfjKwYnsHqCn",
-      "riotHandle": "@angl:matrix.org"
+      "riotHandle": "@angl:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 50,
       "name": "Barachiel",
       "stash": "HKx2UXV6AhjV6mUGCDJZ2bJRgfmkXCNHXRM1UFDK52ciuDD",
-      "riotHandle": "@angl:matrix.org"
+      "riotHandle": "@angl:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 51,
       "name": "Taiwan 001",
       "stash": "GCNeCFUCEjcJ8XQxJe1QuExpS61MavucrnEAVpcngWBYsP2",
-      "riotHandle": "@yaohsin:matrix.org"
+      "riotHandle": "@yaohsin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 52,
       "name": "ProofOfTrue",
       "stash": "EraxW9FCtQtJpnKSKGPxNSrzASoXpHRhctRs8gZv7C7GvHN",
-      "riotHandle": "@verstak:matrix.org"
+      "riotHandle": "@verstak:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 53,
       "name": "Fennel Validator 0",
       "stash": "Cd2ewfXdQiaUzTBYKSZTzL7hPuB3nzEKMT2y36zJC9QaEG4",
-      "riotHandle": "@romulus10:fennel.ems.host"
+      "riotHandle": "@romulus10:fennel.ems.host",
+      "kyc": false
     },
     {
+      "slotId": 54,
       "name": "🚀PromoTeam🚀 | Validator",
       "stash": "Dm4uKxZJZHJbpZpfnYPiHnbgyHWKMU1s5h6X7kqjfYv1Xkk",
-      "riotHandle": "@alex-m:matrix.org"
+      "riotHandle": "@alex-m:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 55,
       "name": "Stakezilla",
       "stash": "EYLWsnmix2ZYGG1jBedDgUhQQ4cAjpbqH7KvggKYACrBKGr",
-      "riotHandle": "@dczoicas:matrix.org"
+      "riotHandle": "@dczoicas:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 56,
       "name": "canyon-ultimate-4",
       "stash": "EXGbhMrQubm7pRkUSkTEGi2rmR764ZM7kStfCRo2cZYa8VE",
-      "riotHandle": "@joe:web3.foundation"
+      "riotHandle": "@joe:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 57,
       "name": "canyon-ultimate-3",
       "stash": "HngUT2inDFPBwiey6ZdqhhnmPKHkXayRpWw9rFj55reAqvi",
-      "riotHandle": "@joe:web3.foundation"
+      "riotHandle": "@joe:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 58,
       "name": "Cryptonic",
       "stash": "Ffd5sG7N65LEFr4bXbpwvPnpmezwpfrCVDEozH2jkMs1utk",
-      "riotHandle": "@bogdi:matrix.org"
+      "riotHandle": "@bogdi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 59,
       "name": "Spellcaster",
       "stash": "F7c6ocWu397zYewAHBxqTwHgXhXDebgYSVjRX9oQM42hkpn",
-      "riotHandle": "@spellcaster:matrix.og"
+      "riotHandle": "@spellcaster:matrix.og",
+      "kyc": false
     },
     {
+      "slotId": 60,
       "name": "Hsinchu",
       "stash": "CjU6xRgu5f9utpaCbYHBWZGxZPrpgUPSSXqSQQG5mkH9LKM",
-      "riotHandle": "@hsinchu:matrix.org"
+      "riotHandle": "@hsinchu:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 61,
       "name": "Ethical Validators 0",
       "stash": "DbDAmhLFMhSQkZjnmAYjSktubPiSYKs6ubGtUmt5uC4eHzm",
-      "riotHandle": "@evaluators:matrix.org"
+      "riotHandle": "@evaluators:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 62,
       "name": "blockzilla",
       "stash": "EJi7cj4VsdyJvEXnyLptuh8pWQ2ycswHTsGui3AbfhStuyT",
-      "riotHandle": "@blockzilla.team:matrix.org"
+      "riotHandle": "@blockzilla.team:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 63,
       "name": "Binary Holdings",
       "stash": "GKEvLVdBEvjHyU77Ai1aPR6KdfVfoAEUQVfUk8uFTQQfvmT",
-      "riotHandle": "@tacoturtle:matrix.org"
+      "riotHandle": "@tacoturtle:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 64,
       "name": "Binary Holdings 0010",
       "stash": "HDbZDq8aW1pDbgzQcGK9Mzr8FnrRWHsoiXMSBVnoLwzy7HC",
-      "riotHandle": "@tacoturtle:matrix.org"
+      "riotHandle": "@tacoturtle:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 65,
       "name": "Taichung",
       "stash": "EMrTktHLYSHAqpVH3f2KMMoLkZPMWjeQAZLpZTJ6KgNcXVr",
-      "riotHandle": "@taichung:matrix.org"
+      "riotHandle": "@taichung:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 66,
       "name": "MurterZlarin",
       "stash": "D5WxiuCkRfGrFpRjH4uvmjdUQYH6bvHXiUVYp4eRnr7E1DA",
-      "riotHandle": "@kizos:matrix.org"
+      "riotHandle": "@kizos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 67,
       "name": "lab-node-ddd1",
       "stash": "FPwa55diVEYwSuhNXwDACk31u4BTe2kgC255BsibKJwFksc",
-      "riotHandle": "@kogeler:matrix.org"
+      "riotHandle": "@kogeler:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 68,
       "name": "Staker Space [3]",
       "stash": "Dm64aaAUyy5dvYCSmyzz3njGrWrVaki9F6BvUDSYjDDoqR2",
-      "riotHandle": "@gnossienli:matrix.org"
+      "riotHandle": "@gnossienli:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 69,
       "name": "redpenguin",
       "stash": "G7mWyu1Pom5XreLHUzDEcvFp6WaMuLuo4QKxtDB9yJZnH69",
-      "riotHandle": "@redpenguin:matrix.org"
+      "riotHandle": "@redpenguin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 70,
       "name": "OnfinalityV#1",
       "stash": "HRuaGanNmkmeQgZPWPXmkZJb944raNS5ni2vhKzhz75zVYP",
-      "riotHandle": "@ianhe:matrix.org"
+      "riotHandle": "@ianhe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 71,
       "name": "Nodeasy",
       "stash": "CczSz9z41uHpftVviWz91TgjLe3SmbvXfbAc958cjy7F6Qs",
-      "riotHandle": "@crabbean:matrix.org"
+      "riotHandle": "@crabbean:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 72,
       "name": "tsuki-validator-1",
       "stash": "H4DWZHkKgeQtV4J632xcFr3xy34iyK4hLxZctVgF8UsacJN",
-      "riotHandle": "@nasamura:matrix.org"
+      "riotHandle": "@nasamura:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 73,
       "name": "Cosmoon",
       "stash": "CmjHFdR59QAZMuyjDF5Sn4mwTgGbKMH2cErUFuf6UT51UwS",
-      "riotHandle": "@gregorst:matrix.org"
+      "riotHandle": "@gregorst:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 74,
       "name": "ZENIT",
       "stash": "Gf7EHcqRZiXCELr2xYjQXrxAzVcEFh5pEjvQdedKS2avGAj",
-      "riotHandle": "@cash__azimut:matrix.org"
+      "riotHandle": "@cash__azimut:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 75,
       "name": "KeepNode-Carbon",
       "stash": "GqberYLwXKzYdopusK5szaZSjxPNDYsUQe4zjDZnHMoCWZ8",
-      "riotHandle": "@Drun:matrix.org"
+      "riotHandle": "@Drun:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 76,
       "name": "Anon-1",
       "stash": "EkWkbLnosJaPVzVmKMFay2HBQGV5FqGJ75q1x6vdvYoY19Y",
-      "riotHandle": "@rok_anonstake:matrix.org"
+      "riotHandle": "@rok_anonstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 77,
       "name": "prematurata",
       "stash": "H72hS8xLmSiSBqbBXHND2KbN8PAoevi52B685cbGki6T9nt",
-      "riotHandle": "@prematurata:matrix.org"
+      "riotHandle": "@prematurata:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 78,
       "name": "Sachiko",
       "stash": "EQF693vsen6WxMdoYgf2cypvH4saFJWFzDupoFUT79MffeW",
-      "riotHandle": "@sachik0:matrix.org"
+      "riotHandle": "@sachik0:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 79,
       "name": "ondin",
       "stash": "HWAGAxX2PAzNVg7w3ZyTprH5yvwbVwQ8rbWwuZxtQKbQupW",
-      "riotHandle": "@ondin:matrix.org"
+      "riotHandle": "@ondin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 80,
       "name": "ALESSIO-0",
       "stash": "GaK38GT7LmgCpRSTRdDC2LeiMaV9TJmx8NmQcb9L3cJ3fyX",
-      "riotHandle": "@ironoa:matrix.org"
+      "riotHandle": "@ironoa:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 81,
       "name": "luckyve",
       "stash": "EDNEfKXHd645DPpBhLZjaEwp4sPhj4STjjS4QrMbFU1FqbZ",
-      "riotHandle": "@luckyve:matrix.org"
+      "riotHandle": "@luckyve:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 82,
       "name": "Jormungand_Labs",
       "stash": "G7xzXN3ddsqcsPswNKRhroyptEsh1oakjQ98K7fRZUTUvkr",
-      "riotHandle": "@mortgray:matrix.org"
+      "riotHandle": "@mortgray:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 83,
       "name": "stake-machine",
       "stash": "EchB8XdgqCWS6dbBzhrgtPtrADfyQV9qRAAC9Q7dWbpYZVS",
-      "riotHandle": "@akme:matrix.org"
+      "riotHandle": "@akme:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 84,
       "name": "ANAMIX1000",
       "stash": "Ekcq8AKv5ggU1qUHbSAVoxmLXuut3oqqwSPWDYRjnHjoXHq",
-      "riotHandle": "@dbpatty:matrix.org"
+      "riotHandle": "@dbpatty:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 85,
       "name": "dakkk",
       "stash": "HX6qEdgi3eFMasuBwtVFLKKtKVJzHAAK17pLyB7SxkxCASD",
-      "riotHandle": "@dakkk:matrix.org"
+      "riotHandle": "@dakkk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 86,
       "name": "dakkk2",
       "stash": "G2JyVQGxihdKXDBCC6BYNvsrY9NT4CsxfJ9dF1kjsyX2PJv",
-      "riotHandle": "@dakkk:matrix.org"
+      "riotHandle": "@dakkk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 87,
       "name": "djandre",
       "stash": "EyZZCbvA9NybsZuR28pFn7fBK9mun8Twgb8tAKuf1taJZie",
-      "riotHandle": "@djandre77:matrix.org"
+      "riotHandle": "@djandre77:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 88,
       "name": "HashQuark",
       "stash": "D8BfryaM5xN62UuKUpLK5zbZEUSBtA76yP9YddQTKXi9pkB",
-      "riotHandle": "@lester:matrix.org"
+      "riotHandle": "@lester:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 89,
       "name": "bolinas-201",
       "stash": "GCporqtiw7ybKYUqAftjvUAjZnp3x9gfrWsTy1GrvrGwmYT",
-      "riotHandle": "@zeke:matrix.parity.io"
+      "riotHandle": "@zeke:matrix.parity.io",
+      "kyc": false
     },
     {
+      "slotId": 90,
       "name": "BladeRunner2",
       "stash": "CvXauCCmKbwptHsMcqWzTBFzZ7KEfMwY69AjdLLmr7DfW9j",
-      "riotHandle": "@d3ckard:matrix.org"
+      "riotHandle": "@d3ckard:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 91,
       "name": "Sio34",
       "stash": "GCzeGccTUJaJSsUHWKaPb5AKiHP8oxm6jJsxDjMbEtNGf2H",
-      "riotHandle": "@sio34:matrix.org"
+      "riotHandle": "@sio34:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 92,
       "name": "ilgio",
       "stash": "Cdhjt72TSezVDkUzdgyoSwXByfwQJjuXSYcDs5L8snyB8Yx",
-      "riotHandle": "@ilgio:matrix.org"
+      "riotHandle": "@ilgio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 93,
       "name": "Stakin 3",
       "stash": "DDdwYhRXzGWBvvaqMEQ7acJs21FiB96L7nnJZfq6HxseFxW",
-      "riotHandle": "@edwardl:matrix.org"
+      "riotHandle": "@edwardl:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 94,
       "name": "redpenguin2",
       "stash": "HHdNWih8aLj9LMTb5j67TCuJijmQADCgizBmfB2vVrvcszZ",
-      "riotHandle": "@redpenguin:matrix.org"
+      "riotHandle": "@redpenguin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 95,
       "name": "IL4R141",
       "stash": "CmWzMp9is3LgQFWY6qtvkEUft57NXVVbXxKxarHjxPCrTtu",
-      "riotHandle": "@il4r141:matrix.org"
+      "riotHandle": "@il4r141:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 96,
       "name": "Polkadotters",
       "stash": "FVAFUJhJy9tj1X4PaEXX3tDzjaBEVsVunABAdsDMD4ZYmWA",
-      "riotHandle": "@pmensik:matrix.org"
+      "riotHandle": "@pmensik:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 97,
       "name": "stake_su",
       "stash": "D5p4fKuhggjXRxiZ4JuPTCGYpDM6Dp9VRxjsYCeVg7LYv5a",
-      "riotHandle": "@mr.ownage:matrix.org"
+      "riotHandle": "@mr.ownage:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 98,
       "name": "andreita-validator-0",
       "stash": "EyTegKZ9DBvMkV6pMbjx2fRk3N2VLNNduuto1PGpYcEqRrX",
-      "riotHandle": "@andreita:matrix.org"
+      "riotHandle": "@andreita:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 99,
       "name": "SynerWork Inc",
       "stash": "F7hDMvu33u14QPXbkBzqF4CuuyyruB2xi6D3V7aUbY8KGpr",
-      "riotHandle": "@synerwork:matrix.org"
+      "riotHandle": "@synerwork:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 100,
       "name": "ilgio2",
       "stash": "EfeoSg3WEZo5kp3BKfwhwwJkh4GdSaS9MjaeH2nKREDovzw",
-      "riotHandle": "@ilgio:matrix.org"
+      "riotHandle": "@ilgio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 101,
       "name": "Ubik Capital",
       "stash": "DwJnksma9utUsT31bzf7eUwkDBetZhFzD3bJLE1uBZ5udHN",
-      "riotHandle": "@anuntjocuri:matrix.org"
+      "riotHandle": "@anuntjocuri:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 102,
       "name": "HashQuark 02",
       "stash": "FLdSKZjwaVuLpR2aPRi5csvsWgV6ZA3vZu58qx36oXukM63",
-      "riotHandle": "@lester:matrix.org"
+      "riotHandle": "@lester:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 103,
       "name": "🏢 MIDL_dev_1",
       "stash": "GyrcqNwF87LFc4BRxhxakq8GZRVNzhGn3NLfSQhVHQxqYYx",
-      "riotHandle": "@okp:matrix.org"
+      "riotHandle": "@okp:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 104,
       "name": "cryptids_picsou",
       "stash": "JDEgrmpP97qu8UoTjm2Ra8wJUrXFrunabsnyQ2bZRspf9r6",
-      "riotHandle": "@cryptids:matrix.org"
+      "riotHandle": "@cryptids:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 105,
       "name": "Bartalamew",
       "stash": "GHWU4uLy8noYVgKD1UoxHEQ9NvHg64R4jYsCp1nSq5iDgbJ",
-      "riotHandle": "@bartalamew:matrix.org"
+      "riotHandle": "@bartalamew:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 106,
       "name": "Saxemberg4",
       "stash": "GL7MYnpQr7jgJqK8wSRUQuob1TvTY7uRJP6LUNeUyvMUhQR",
-      "riotHandle": "@s_saxemberg:matrix.org"
+      "riotHandle": "@s_saxemberg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 107,
       "name": "AGx2",
       "stash": "FWxYu7XrMuCvKqyKQntmDsKgAtgYHa2KHiS3tijcLwyjnih",
-      "riotHandle": "@agx10000:matrix.org"
+      "riotHandle": "@agx10000:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 108,
       "name": "XUAN_LOW_COMMISSION_NODE",
       "stash": "HvumdQbk47PXTz57UDrZP5n8rmgf27upC1ooPjtZf9XA2Wk",
-      "riotHandle": "@xuan93:matrix.org"
+      "riotHandle": "@xuan93:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 109,
       "name": "TheGuild",
       "stash": "Gnn9xyFiZYXtKeMfZSSWSdSvxv9go1KCq2kgfyyGcAoZ3pL",
-      "riotHandle": "@theguild:matrix.org"
+      "riotHandle": "@theguild:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 110,
       "name": "Indigo Two",
       "stash": "HHWm4YjgJjKv8xrCokUshUKhGfsdbBmjoNV6aGWVgAznZEr",
-      "riotHandle": "@shadewolf:matrix.org"
+      "riotHandle": "@shadewolf:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 111,
       "name": "PureStake_Kusama_03",
       "stash": "DVw4Zkfva2MPibAsr8vgoha1T2ow8zreoTWGyBDioQBdfMM",
-      "riotHandle": ["@artk:matrix.org", "@mitchell-g:matrix.org"]
+      "riotHandle": ["@artk:matrix.org", "@mitchell-g:matrix.org"],
+      "kyc": false
     },
     {
+      "slotId": 112,
       "name": "🎠 Forbole 🇭🇰",
       "stash": "Hij7jSP2MA3uYYUhXfWdwK428rN7r2NaKn9y85R3iho2MHQ",
-      "riotHandle": "@kwunyeung:matrix.org"
+      "riotHandle": "@kwunyeung:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 113,
       "name": "Synapticon ॐ The Fool",
       "stash": "DroGa6vgtDuLFEhPmTUfLMMeTJQH3h8tCzCDTUTQYcVwmuZ",
-      "riotHandle": "@synapticon:matrix.org"
+      "riotHandle": "@synapticon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 114,
       "name": "SynerWork Inc #2",
       "stash": "FMBvL5eqMoCzoR5Rd3p4WKhSbzQGEkpMDBvY1jr431PGa4s",
-      "riotHandle": "@synerwork:matrix.org"
+      "riotHandle": "@synerwork:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 115,
       "name": "openbitlab",
       "stash": "EA9YDzksfSR3RjM5TzKS7bdvEzi7bycXLK15o5g6XTFxFfW",
-      "riotHandle": "@openbitlab_:matrix.org"
+      "riotHandle": "@openbitlab_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 116,
       "name": "Good Karma",
       "stash": "JKbJoCsgUEgjbGmGq7VdSNgSVQt8k43e3WWAYGCpiNP9r6D",
-      "riotHandle": "@themarcus:matrix.org"
+      "riotHandle": "@themarcus:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 117,
       "name": "ANAMIX",
       "stash": "F7Wa1su7NRSr6LWuhPWdXcQALDyzm8Vmev7WtV5jVPtJELs",
-      "riotHandle": "@dbpatty:matrix.org"
+      "riotHandle": "@dbpatty:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 118,
       "name": "Dionysus-sv-validator-0",
       "stash": "FWz717J6ATaYSNy2tRHAskEC9SP4uKHNJYC9mvfvimkB8GT",
-      "riotHandle": ["@syed:web3.foundation", "@remohammdi:matrix.org"]
+      "riotHandle": ["@syed:web3.foundation", "@remohammdi:matrix.org"],
+      "kyc": false
     },
     {
+      "slotId": 119,
       "name": "CoinStudio",
       "stash": "GCMGu8sjEuEZuMZavo5PLvAhr8fJXAty76jDV1YPquG9erp",
-      "riotHandle": "@coinstudio:matrix.org"
+      "riotHandle": "@coinstudio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 120,
       "name": "nodera-validator",
       "stash": "DMkKL7AZw9TkNw2NaBdocmFRGUG8r8T4kdGGcB13fv2LARy",
-      "riotHandle": "@paride_f:matrix.org"
+      "riotHandle": "@paride_f:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 121,
       "name": "FIGMENT",
       "stash": "Ehj9QgHDku6gewzD87mqeZzYixwqLYEYrEjUiem1Q7sRXMY",
-      "riotHandle": "@mattharrop:matrix.org"
+      "riotHandle": "@mattharrop:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 122,
       "name": "FIGMENT (2)",
       "stash": "Fhn8iazUm9uNvM9uJ2apCfuK2KTN9qJSZ7x33bJZjjgHcHR",
-      "riotHandle": "@mattharrop:matrix.org"
+      "riotHandle": "@mattharrop:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 123,
       "name": "OnFinalityV#2",
       "stash": "DzmvnHyHyPN2kBHYQpXmrrUvV8KNzDgTPE2Ri2cjDuXhhLt",
-      "riotHandle": "@ianhe:matrix.org"
+      "riotHandle": "@ianhe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 124,
       "name": "SEKOYA LABS",
       "stash": "J73TGAeL5U5SFMmMB3fS9gxcGKMS9gsHTyhrFQg8Lx9gfhA",
-      "riotHandle": "@stewartv:matrix.org"
+      "riotHandle": "@stewartv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 125,
       "name": "Any",
       "stash": "G9eQP5W6mfLg3Sx4EfJ9YCGoxH5HFXmxENy7DA8ExbTmS4a",
-      "riotHandle": "@anyd:matrix.org"
+      "riotHandle": "@anyd:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 126,
       "name": "Stakin 4",
       "stash": "GwCVDk8c1QgdJnWLHJn3rfPEYW9sUce3zSUrXaM7kxVWvLw",
-      "riotHandle": "@edwardl:matrix.org"
+      "riotHandle": "@edwardl:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 127,
       "name": "Everstake 2",
       "stash": "EMP286w89JTpvfRP2MKSWKgn9YiPw1JVTjmxdmVvcCzvim8",
-      "riotHandle": "@vit_everstake:matrix.org"
+      "riotHandle": "@vit_everstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 128,
       "name": "Cosmoon2",
       "stash": "H8FCosmkRAgDevcgEppkgcmZLLurh3otcXsyeSZdWDHNJwf",
-      "riotHandle": "@gregorst:matrix.org"
+      "riotHandle": "@gregorst:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 129,
       "name": "KUKU-0",
       "stash": "FaBN1AxtJu21x2cUqvdF5VcVUAfzfqyvJPvwgsdwo3pkdr9",
-      "riotHandle": "@repe:matrix.org"
+      "riotHandle": "@repe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 130,
       "name": "Zetetic Validator",
       "stash": "GD6MTUJG9Ym7tS6PLF42yreHpqpvFgPcqPwcyRGiMv2TSGR",
-      "riotHandle": "@zeteticvalidator:matrix.org"
+      "riotHandle": "@zeteticvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 131,
       "name": "waterproof",
       "stash": "GNvW8KgQX4SweRW6Pq4oPaHc8BLEeYnUq5R3tSVcUFfQSRZ",
-      "riotHandle": "@firegrass:matrix.org"
+      "riotHandle": "@firegrass:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 132,
       "name": "hirish",
       "stash": "Eg19soJDW6GM387LPtrszyeQ93nuUZiGdUsbJbKqekKAPab",
-      "riotHandle": "@hirish:matrix.org"
+      "riotHandle": "@hirish:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 133,
       "name": "Mile-Delta",
       "stash": "HmATBxduU6c5ZCCJaXMVNQZ1UF7JYdPLimEo6b35J5btk9y",
-      "riotHandle": "@matherceg:matrix.org"
+      "riotHandle": "@matherceg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 134,
       "name": "Simply Staking 2",
       "stash": "GLJLgrKhPDzSvNCNjQ184si3Fvu3bzSJBzewkzEZRVLV2oe",
-      "riotHandle": "@daniel-svc:matrix.org"
+      "riotHandle": "@daniel-svc:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 135,
       "name": "birb-01",
       "stash": "GZvxvwKGaZyq21BHnrUpdQkpcF4jrCsi23d3c6dvsmp6BF8",
-      "riotHandle": ["@azk:fairydust.space", "@valka:fairydust.space", "@s3krit:fairydust.space"]
+      "riotHandle": [
+        "@azk:fairydust.space",
+        "@valka:fairydust.space",
+        "@s3krit:fairydust.space"
+      ],
+      "kyc": false
     },
     {
+      "slotId": 136,
       "name": "Eat Pray Validate 1 🍴🙏🖥 ",
       "stash": "EPV1c7jjoCFPkWqTzTkbuT3oGRM8HkjbTVHeuvsyiAbB2aZ",
-      "riotHandle": "@yx11xy:matrix.org"
+      "riotHandle": "@yx11xy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 137,
       "name": "Eat Pray Validate 2 🍴🙏🖥",
       "stash": "EPV2HxrBnVB2n4p7Mb38A3BrzCyREWbzQ75cC9rkZhRYcRE",
-      "riotHandle": "@yx11xy:matrix.org"
+      "riotHandle": "@yx11xy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 138,
       "name": "BlockAegis",
       "stash": "HcdBFbGDMFzs5MuYQxFQpTBivHgH1UyFKqQDip9YgmqngKH",
-      "riotHandle": "@porter92:matrix.org"
+      "riotHandle": "@porter92:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 139,
       "name": "Swiss Bond",
       "stash": "EoYkgoLQn1GZrJLmqVMd6GhSJYWtYAtzg3fEcWH6nXjscqC",
-      "riotHandle": "@matteo_swissbond:matrix.org"
+      "riotHandle": "@matteo_swissbond:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 140,
       "name": "soramitsu-validator-3",
       "stash": "HXPQBH5oLAZcarqtmchGJNzjbfQS8WFM5F1A3jPvit387pH",
-      "riotHandle": "@soramitsu-ops:matrix.org"
+      "riotHandle": "@soramitsu-ops:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 141,
       "name": "soramitsu-validator-4",
       "stash": "HkWiVG6ZSmgEgiS74A8YEHwPm47PeRM3sAHxapKrm3DZXEb",
-      "riotHandle": "@soramitsu-ops:matrix.org"
+      "riotHandle": "@soramitsu-ops:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 142,
       "name": "Allnodes",
       "stash": "DrcpVMV5dExRfYh1vcSgZLBfzW7cKjU18ZktNDqesNEs31B",
-      "riotHandle": "@seph1roth:matrix.org"
+      "riotHandle": "@seph1roth:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 143,
       "name": "Mile-Bravo",
       "stash": "HMATevKkCxh3Z4gDJuqeB19ckmoxXN7RH7dfSPq1HhciX77",
-      "riotHandle": "@matherceg:matrix.org"
+      "riotHandle": "@matherceg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 144,
       "name": "Bluefin_Tuna",
       "stash": "CbaNLeJQ8e8aCJMTLa9euDKuTDmnT5oPmGFt4AmuvXmYFGN",
-      "riotHandle": "@bluefin_tuna:matrix.org"
+      "riotHandle": "@bluefin_tuna:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 145,
       "name": "🏢 MIDL_dev_2",
       "stash": "Fs72xecWY6SRwKNH2voodiSsdVKeath4kofHEGsZGLibSxh",
-      "riotHandle": "@okp:matrix.org"
+      "riotHandle": "@okp:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 146,
       "name": "⛰ HELIKON ⛰ ISTANBUL",
       "stash": "GC8fuEZG4E5epGf5KGXtcDfvrc6HXE7GJ5YnbiqSpqdQYLg",
-      "riotHandle": "@helikon:matrix.org"
+      "riotHandle": "@helikon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 147,
       "name": "🧊 Iceberg Nodes 🧊 | V1",
       "stash": "Eices1KaGTYqiazfjJpwyjnz5UzqTxULeYqnmeJNz49gs19",
-      "riotHandle": "@icebergnodes:matrix.org"
+      "riotHandle": "@icebergnodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 148,
       "name": "Allnodes2",
       "stash": "HgNrFcEToXx64kDtmB6zh375zDrEUE6vLQJgQdmxGje14TA",
-      "riotHandle": "@seph1roth:matrix.org"
+      "riotHandle": "@seph1roth:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 149,
       "name": "GoOpen",
       "stash": "JJiV1xrj1814BVDDG2pFCsgzdbR7K29VcyXQGXEUhn7LWhK",
-      "riotHandle": "@alko89:matrix.org"
+      "riotHandle": "@alko89:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 150,
       "name": "==ELDORADO-Validator==",
       "stash": "Cp2kxaQCVbPCfEc1T2tFxvMWvaUDuuKqSfhxnkDjuLk3bxy",
-      "riotHandle": "@paul-gie:matrix.org"
+      "riotHandle": "@paul-gie:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 151,
       "name": "bLdn0d3",
       "stash": "Hf8C626KBAjitMV7w8AhQWDCiPgUU47htEwbomq5mDMKeyL",
-      "riotHandle": "@bld759:matrix.org"
+      "riotHandle": "@bld759:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 152,
       "name": "Northwoods-A",
       "stash": "HZU7Hkai2LZkP6BRCUEWiGSkhaNJoaPgroYEKtKkMHwTTY6",
-      "riotHandle": "@northwoods-support:matrix.org"
+      "riotHandle": "@northwoods-support:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 153,
       "name": "Northwoods-B",
       "stash": "DdenGrPKBYbExerMSNw2WYfq7kR6W8TKKvJw7SSmRJU7Qpn",
-      "riotHandle": "@northwoods-support:matrix.org"
+      "riotHandle": "@northwoods-support:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 154,
       "name": "Bricksz",
       "stash": "GcYjMe8hksoYUB6sdWBbgWGJL22pZFg1FmDBALqbRSds2fZ",
-      "riotHandle": "@bricksz:matrix.org"
+      "riotHandle": "@bricksz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 155,
       "name": "validchains-validator",
       "stash": "FcisXpcVqJ2PGUNhikMUwciEWncuei5PkNgMc9qmsxqQH7o",
-      "riotHandle": "@cg158356:matrix.org"
+      "riotHandle": "@cg158356:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 156,
       "name": "fireproof",
       "stash": "J3f7ULfjVbbBYvZtMvaEDiUC8odXjt2A2hGShshBFCKHazY",
-      "riotHandle": "@firegrass:matrix.org"
+      "riotHandle": "@firegrass:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 157,
       "name": "Mitch-Wariner",
       "stash": "FS8nKS5ReuaA999xUKTEzDDCA8BXyyrxD73KKyqwbRRt2Hf",
-      "riotHandle": "@mitch-wariner:matrix.org"
+      "riotHandle": "@mitch-wariner:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 158,
       "name": "Para-KSM1-Validator",
       "stash": "F8H3cT1XKWHbkWSRhyVbRgpqn1nLhXGCL1uUdXQJmavpACQ",
-      "riotHandle": "@paradoxxx:matrix.org"
+      "riotHandle": "@paradoxxx:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 159,
       "name": "legos-y",
       "stash": "EFysEttiUwYAYu3CAgqmySCmRQ43ucBvgi4Dm1Sfgm4DqG7",
-      "riotHandle": "@legos:matrix.org"
+      "riotHandle": "@legos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 160,
       "name": "Nic0",
       "stash": "CaVLqgMmajk7ySYjo4SPqauXwsZu8Y5tP9vVDvJvcecbp3n",
-      "riotHandle": "@sachik0:matrix.org"
+      "riotHandle": "@sachik0:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 161,
       "name": "CertHum-MaxStake-sv-validator-0",
       "stash": "EpeeGt1x3kju8TZmfcaHTkBwTn7eyq4Sxy8Z3dPU88chMcN",
-      "riotHandle": "@certhum-jim:matrix.org"
+      "riotHandle": "@certhum-jim:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 162,
       "name": "CertHum-MaxStake-sv-validator-1",
       "stash": "FVwmuHZRbnEBrA6ya4SYAGt9ChtZWqqjgF2H758mAcHMhuW",
-      "riotHandle": "@certhum-jim:matrix.org"
+      "riotHandle": "@certhum-jim:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 163,
       "name": "e4y_io",
       "stash": "DdkRZjqtZUXdN6XGR8tuoUSEmWgQYwoUR8PQXLdnyp44JLy",
-      "riotHandle": "@e4y.io:matrix.org"
+      "riotHandle": "@e4y.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 164,
       "name": "🐑 Hodl_dot_farm D 🐑",
       "stash": "DuNrThu8caNYMmtHt5BNF2Cz8JzhkaKuwQfPDax7rz2YXFz",
-      "riotHandle": "@hodl_farm:matrix.org"
+      "riotHandle": "@hodl_farm:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 165,
       "name": "Stakely",
       "stash": "EfcQCKZJaNu2vcrpnJDCoh1ub4mGWcHVzeU8ghUH7Co9rui",
-      "riotHandle": "@iicc1:matrix.org"
+      "riotHandle": "@iicc1:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 166,
       "name": "legos-x",
       "stash": "EHAgisQqE3paxAC694qumC9QLmGSJTRT1vEMJ8FUK744ixS",
-      "riotHandle": "@legos:matrix.org"
+      "riotHandle": "@legos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 167,
       "name": "e4y_io-2",
       "stash": "D3Fh5td8SjuWn3GR7WEQyZx6TncxwFLaix2YTvygMyxDcU9",
-      "riotHandle": "@e4y.io:matrix.org"
+      "riotHandle": "@e4y.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 168,
       "name": "Para-KSM2-Validator",
       "stash": "ExWRdMwU8JLrfaQvGJ6TxhtTbxjCtcLhbVQoSXLANywK6uo",
-      "riotHandle": "@paradoxxx:matrix.org"
+      "riotHandle": "@paradoxxx:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 169,
       "name": "STAKINGDX_COM",
       "stash": "FeuqakbGhvLMwvpqxocPounn7xbLR1xJN4U6fK1ibeJbuh8",
-      "riotHandle": "@stakingdx:matrix.org"
+      "riotHandle": "@stakingdx:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 170,
       "name": "Shotmaker",
       "stash": "Hv8d8xLhJTTggzMCR3oUgmqCgQYuNfUu7syq7q1Lo9cAXg2",
-      "riotHandle": "@controller.controller:matrix.org"
+      "riotHandle": "@controller.controller:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 171,
       "name": "turboflakes-1",
       "stash": "FUu6iSzpfStHnbtbzFy2gsnBLttwNgNSULSCQCgMjPfkYwF",
-      "riotHandle": "@turboflakes:matrix.org"
+      "riotHandle": "@turboflakes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 172,
       "name": "VisionStake-KSM",
       "stash": "GLxyY9cx27VkZNrf33zHURwLLa58jU8XZeg8HDWkNpX2JXS",
-      "riotHandle": "@visionstake:matrix.org"
+      "riotHandle": "@visionstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 173,
       "name": "Nozomi Stations",
       "stash": "Et9EGzNv7jcCcArsv4PVRM6zectyWnV5BE7xfjAmMsVA62i",
-      "riotHandle": "@nozomihq:matrix.org"
+      "riotHandle": "@nozomihq:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 174,
       "name": "Vegas_life_main-DO",
       "stash": "Dq97kmsJXGTciU1eMXZMAp4D41Y9e7kQ4hmFBfZW7YD4CCf",
-      "riotHandle": "@ccris02:matrix.org"
+      "riotHandle": "@ccris02:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 175,
       "name": "maxxrer57",
       "stash": "GoF8Dm7hrdE6Dec21ymD2P5M9bHWPU3Xwb5NipGqnsuJg4v",
-      "riotHandle": "@maxxrer:matrix.org"
+      "riotHandle": "@maxxrer:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 176,
       "name": "kusama-badger-validator-01",
       "stash": "DG1TPMPi6haZsUUgXSoMwNsUW198EXBu7Wd7EGU1KdfEag1",
-      "riotHandle": "@lilok:matrix.org"
+      "riotHandle": "@lilok:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 177,
       "name": "DOT_KSM_STK",
       "stash": "ES61whRwU1AgXx7zbq9KxK2SiuWtiLWbXKowsqLraa8WC9A",
-      "riotHandle": "@dotksmstk:matrix.org"
+      "riotHandle": "@dotksmstk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 178,
       "name": "Ancibanci",
       "stash": "DaNCiojAyKWjXDLxiHLrpMvD36hgKpvrYD3Xqf31RNDqXKT",
-      "riotHandle": "@ancibanci:matrix.org"
+      "riotHandle": "@ancibanci:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 179,
       "name": "validathor",
       "stash": "J9UpatjuWWrB5svWSNAGAiBQ4wV6pWXT74KemnFFURaSTvg",
-      "riotHandle": "@yoneck:matrix.org"
+      "riotHandle": "@yoneck:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 180,
       "name": "🚂 Zugian Duck 🦆",
       "stash": "HCAYcNgeMLCXjg9ifeJc6uBaesPv9WHMLm4XT45sqMK2h1H",
-      "riotHandle": "@robert:web3.foundation"
+      "riotHandle": "@robert:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 181,
       "name": "Kusama XI Validator",
       "stash": "ESSZefozpZYVLbLF1vaGtabthQYg8PVXiTytVm6YiiwAnee",
-      "riotHandle": "@hitchhooker:matrix.org"
+      "riotHandle": "@hitchhooker:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 182,
       "name": "thirdwave-network-validator-bis",
       "stash": "FUbMLUvMq3tnJK7jX8TaZmRCX9yRqEFNLsKK3K1UtfZw16v",
-      "riotHandle": "@tomaszwaszczyk:matrix.org"
+      "riotHandle": "@tomaszwaszczyk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 183,
       "name": "🛡 DWELLIR KSM 🛡",
       "stash": "DuLr6CeLXezrfumF6EkqLeAx9paMcADYU6zHpSZVB8gvjht",
-      "riotHandle": "@dwellir:matrix.org"
+      "riotHandle": "@dwellir:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 184,
       "name": "PineappleXpress-sv-validator-0",
       "stash": "GFCnULt6joMQEMM1yHuGQZCZpxw7kVKu3XkFZxcdxGbF3pu",
-      "riotHandle": "@okojamo:matrix.org"
+      "riotHandle": "@okojamo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 185,
       "name": "XUAN_LOW_COMMISSION_NODE_2",
       "stash": "JHwBvr7JeNXW8S8JL7wumsvqYZ8Kf2W1xrYn5nS1Z8p81VL",
-      "riotHandle": "@xuan93:matrix.org"
+      "riotHandle": "@xuan93:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 186,
       "name": "n-fuse-kusama-val-1",
       "stash": "DosV2kyxoKTd9GXMDk84XsN78ZXteAdzaQMrk9YofUscuZn",
-      "riotHandle": "@vanthome:matrix.org"
+      "riotHandle": "@vanthome:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 187,
       "name": "Nozomi Stations 2",
       "stash": "ESim2HZyCnh7Qa56Y4q7h2CrYHuHHJt76d9fzUCpRxNY65v",
-      "riotHandle": "@nozomihq:matrix.org"
+      "riotHandle": "@nozomihq:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 188,
       "name": "StakePool247/2",
       "stash": "CdGbSf2VbjxASSKMfLm2nCmPKnU75hPEgxYYWUvQHCDAVAu",
-      "riotHandle": "@StakePool247:matrix.org"
+      "riotHandle": "@StakePool247:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 189,
       "name": "michalis",
       "stash": "FZyFBAqs93TenupzDHJzW1pxFLxwwo1EJLvT89jhrV368yb",
-      "riotHandle": "@michalis:web3.foundation"
+      "riotHandle": "@michalis:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 190,
       "name": "VisionStake-KSM-2",
       "stash": "Cw2HqJ6m2pXVDatzZq8wNdUWwWaCnYLeyTM24ft3JNdZ25E",
-      "riotHandle": "@visionstake:matrix.org"
+      "riotHandle": "@visionstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 191,
       "name": "cryptobees-validator",
       "stash": "Hg5nkQvtyrKvvP3dBP1hDRWhjtVB7uxsrjSFemH3np7GdJY",
-      "riotHandle": "@cryptobee:matrix.org"
+      "riotHandle": "@cryptobee:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 192,
       "name": "Stampede",
       "stash": "JBwJ33SrTv6jFZroGBWNdpR2Kat3GW5CfSvhDFqvwxLUU4C",
-      "riotHandle": "@stampede_jon:matrix.org"
+      "riotHandle": "@stampede_jon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 193,
       "name": "hirish_2",
       "stash": "FffWuApGjFgHikQWG6ivzJxzRnwqRAgu8dTME3tuv5pBNZ9",
-      "riotHandle": "@hirish:matrix.org"
+      "riotHandle": "@hirish:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 194,
       "name": "COMPUTECRYPTO",
       "stash": "EwxPgctMzko7q2zQSLv4WnXzHBRfXx4twmm4X4bnEMZmW1M",
-      "riotHandle": "@computecrypto:matrix.org"
+      "riotHandle": "@computecrypto:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 195,
       "name": "Logan",
       "stash": "FkWQJswxegj5BSuRULMiw6i79NawgC2ZhqRtoeaLY2xFk2W",
-      "riotHandle": "@logantg:matrix.org"
+      "riotHandle": "@logantg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 196,
       "name": "Zetetic Validator 1",
       "stash": "HCNsMq8BbUzBkrrv71LHGca2cSdPhes64uRz8SPp4nEGM54",
-      "riotHandle": "@zeteticvalidator:matrix.org"
+      "riotHandle": "@zeteticvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 197,
       "name": "LEPRECHAUN",
       "stash": "EiVu6mJZWpf4V2GQq1SZ9GQdJfy2SZB7J8y5tcL2Qr1fBoM",
-      "riotHandle": "@polkaleprechaun:matrix.org"
+      "riotHandle": "@polkaleprechaun:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 198,
       "name": "validathor-ii",
       "stash": "Ek82arBQiScrDoBKbCHpTJYJWePW622kFNn4tRffPNUhjcB",
-      "riotHandle": "@yoneck:matrix.org"
+      "riotHandle": "@yoneck:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 199,
       "name": "🗻Basecamp-Denali🗻",
       "stash": "D4NNrK9KchcZr4qJxYREHjWNU4wW92VDy9ieHnRz1ySy32Z",
-      "riotHandle": "@wolfstrom27:matrix.org"
+      "riotHandle": "@wolfstrom27:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 200,
       "name": "🗻Basecamp-Everest🗻",
       "stash": "H6ncnfDfpfi2ijUvEQxUkVTfHv5Hn3ChMBabG4M7Sb6Xc6T",
-      "riotHandle": "@wolfstrom27:matrix.org"
+      "riotHandle": "@wolfstrom27:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 201,
       "name": "ondin2",
       "stash": "GtGGdVhTSiQbMZNnWcGenFABwHJaXK7oLfpPW8epRXRdLPv",
-      "riotHandle": "@ondin:matrix.org"
+      "riotHandle": "@ondin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 202,
       "name": "postchain_io",
       "stash": "EHs5p1TR3SpQXvqAUq7pL4qKWRVNmrvtCT4izncvnk6Kh5W",
-      "riotHandle": ["@postchain_p:matrix.org", "@postchain_d:matrix.org"]
+      "riotHandle": ["@postchain_p:matrix.org", "@postchain_d:matrix.org"],
+      "kyc": false
     },
     {
+      "slotId": 203,
       "name": "Uno Staking",
       "stash": "ERrC6KGicLk5zqhPjzVPWTEz6Vi9P7mW1cwKxDTyXcFEqRb",
-      "riotHandle": "@unostaking:matrix.org"
+      "riotHandle": "@unostaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 204,
       "name": "capnodes0-sv-validator-0",
       "stash": "Eh7owDC9WRj3gUWMHLTYEN18aarNqSa7kguRGuxa8gBr5Zp",
-      "riotHandle": "@hval:matrix.org"
+      "riotHandle": "@hval:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 205,
       "name": "MrHash",
       "stash": "GZKWWW7jXFUTKDZRz9mkGAdsCKyGJbjMedESAF73jyLPajb",
-      "riotHandle": "@mr_hash:matrix.org"
+      "riotHandle": "@mr_hash:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 206,
       "name": "INFRASTRUCTURE CORPORATION/01",
       "stash": "GG1fakzTavhuof7CVaZU7SJxeK1r4ndoxcCrzbgPcZ7sQDx",
-      "riotHandle": "@yayoi-v:matrix.org"
+      "riotHandle": "@yayoi-v:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 207,
       "name": "klever-io",
       "stash": "FFVYPBjmKQiPzEjr2LWT5bSXMpAkEqWtQYZcLFPkJoqvDAP",
-      "riotHandle": "@lvdegouveia:matrix.org"
+      "riotHandle": "@lvdegouveia:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 208,
       "name": "stakepile_1",
       "stash": "J6TTn21p46c1XzXAZPVTGuQwBxFG2JfTwRnAFwgcdE2SWdz",
-      "riotHandle": "@stakepile:matrix.org"
+      "riotHandle": "@stakepile:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 209,
       "name": "KSMNETWORK",
       "stash": "H1bSKJxoxzxYRCdGQutVqFGeW7xU3AcN6vyEdZBU7Qb1rsZ",
-      "riotHandle": "@gtoocool:matrix.org"
+      "riotHandle": "@gtoocool:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 210,
       "name": "ExPeCtCHaoS-COM 209",
       "stash": "FhrqJshDuMTNqvUsihk2LVLuwKZ4DCGEJ91zY71dRmf9SGG",
-      "riotHandle": "@steak-king:matrix.org"
+      "riotHandle": "@steak-king:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 211,
       "name": "🗻GoldenGate-Whitney🗻",
       "stash": "EcaQjvT1QFnsxevgfGud8C33N1f6oQCNqLdcjmRZ8ksAZyh",
-      "riotHandle": "@serbian74:matrix.org"
+      "riotHandle": "@serbian74:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 212,
       "name": "🗻GoldenGate-Shasta🗻",
       "stash": "GzMRuUaHyARHU8gP6GSqDKEUUkJDKakDGhbi9Mwq5hkn7mu",
-      "riotHandle": "@serbian74:matrix.org"
+      "riotHandle": "@serbian74:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 213,
       "name": "HFR 01 - ✨✨💎💎💎✨✨ - 🇫🇷",
       "stash": "HnckZYNj9xyLSUGisSmYfLut9GywSxy3pHnBJKesEzGWp3S",
-      "riotHandle": "@amallyn:matrix.org"
+      "riotHandle": "@amallyn:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 214,
       "name": "d0tk0s-1-sv-validator-0",
       "stash": "Fv2j2uTAQE6jmKzRq6rzbkrVyMvq1TYZsm9AhoQoXo6uhWw",
-      "riotHandle": "@dotstaker:matrix.org"
+      "riotHandle": "@dotstaker:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 215,
       "name": "Legiojuve",
       "stash": "Dff4bQQLGsNbF5iAnsjE9bmTd4oxhmnYJXHnhwBLBjC8aBo",
-      "riotHandle": "@legiojuve:matrix.org"
+      "riotHandle": "@legiojuve:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 216,
       "name": "G-DOT | ARCTIC BREEZE ❄️",
       "stash": "DPdkDRzUV56F5R8fNjZwFx2Uctn173c1UJJXjxQMVMZuCqS",
-      "riotHandle": "@g-dot.tech:matrix.org"
+      "riotHandle": "@g-dot.tech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 217,
       "name": "spicytacoserrano",
       "stash": "G2f6aFnPDGCrr4BivxuUSQWEd6W856mAPwiSWMJ4f2xuWVp",
-      "riotHandle": "@spicytaco:matrix.org"
+      "riotHandle": "@spicytaco:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 218,
       "name": "spicytacohabanero",
       "stash": "EtHmvsFtVRBaET7T8FcU1hA7Pi6CLUsy4sp1kGN72DD28ck",
-      "riotHandle": "@spicytaco:matrix.org"
+      "riotHandle": "@spicytaco:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 219,
       "name": "polkachu-sv-validator-0",
       "stash": "CsKvJ4fdesaRALc5swo5iknFDpop7YUwKPJHdmUvBsUcMGb",
-      "riotHandle": "@songhua:matrix.org"
+      "riotHandle": "@songhua:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 220,
       "name": "☉ lux8_net ☉",
       "stash": "DJN9riW92EEyZFHNthLCRmc8BrC3MDGiiVKCpHX8qcizcmV",
-      "riotHandle": "@ama31337:matrix.org"
+      "riotHandle": "@ama31337:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 221,
       "name": "COMPUTECRYPTO2",
       "stash": "Gpvr66V61fabb5UzuYoCyJLUjPNaQ7LRwjNuQHgyBraq5Ww",
-      "riotHandle": "@computecrypto:matrix.org"
+      "riotHandle": "@computecrypto:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 222,
       "name": "PlusV",
       "stash": "FfbuQ6wUEfGKxCQpiQcxfMBY5oxKBHiGQVDzAz61Ui57TPY",
-      "riotHandle": "@nagaina:matrix.org"
+      "riotHandle": "@nagaina:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 223,
       "name": "KSMNETWORK-WEST",
       "stash": "GREVfZSgcQjmPgGfx9Y4WNfnqa9Jz96pQdHQzwMUwYcVeGa",
-      "riotHandle": "@gtoocool:matrix.org"
+      "riotHandle": "@gtoocool:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 224,
       "name": "polkachu-kusama-5",
       "stash": "G1qbViqnm6yCZwEbfB4oE38ro8VqJx21zyvW7QN8zAJC2B7",
-      "riotHandle": "@songhua:matrix.org"
+      "riotHandle": "@songhua:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 225,
       "name": "STARDUST STAKING",
       "stash": "G4ZLdEFaJBK7BfikyUCHuJ5ttmuivAeGihnGFWX1VDgDteE",
-      "riotHandle": "@stardust-staking:matrix.org"
+      "riotHandle": "@stardust-staking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 226,
       "name": "Liberty / Murray Rothbard",
       "stash": "FUJYqVYujnZNsTKxrHfyhAJv1v8nPodc4LEiSHvBBYzK4Kn",
-      "riotHandle": "@blxxd:matrix.org"
+      "riotHandle": "@blxxd:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 227,
       "name": "stakezone",
       "stash": "G7Ur4BnMSfP2qE7ruSob5gwGQ5nzkGWu7Yqh14FcMqnDtgB",
-      "riotHandle": "@stakezone:matrix.org"
+      "riotHandle": "@stakezone:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 228,
       "name": "TUPE-val-0",
       "stash": "EhywSEhJJ63mGaJV4VSN7n1wLtyLcFN7x34bptXaCzG8a5R",
-      "riotHandle": "@hvelayos:matrix.org"
+      "riotHandle": "@hvelayos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 229,
       "name": "Lunar_dot",
       "stash": "CroiANffLtjz44LXp98NqmLxuUW5xxbsruZiRUXdeGFD82a",
-      "riotHandle": "@lunar_dot:matrix.org"
+      "riotHandle": "@lunar_dot:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 230,
       "name": "MOON LAMBOS KSM MURCIELAGO",
       "stash": "Gfc4kpbf1SEGMh9gwiuSkXGmWtBcFwQ9V2zW9oWfSQGYuPH",
-      "riotHandle": "@moonlambos:matrix.org"
+      "riotHandle": "@moonlambos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 231,
       "name": "MoonBirdie",
       "stash": "DbYLJhkNu7Moyp5EYVjHZJVHUxMzFQRaSHHTLq9KumSvg5w",
-      "riotHandle": "@moonbirdie:matrix.org"
+      "riotHandle": "@moonbirdie:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 232,
       "name": "SultanOfStaking",
       "stash": "GUukavjKxAdj4Cb77DiwyNNhCSZ6H4RaSiRqYo1uaYiSWcM",
-      "riotHandle": "@sultanofstaking.com:matrix.org"
+      "riotHandle": "@sultanofstaking.com:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 233,
       "name": "Amiga Staking",
       "stash": "Ew4JDQENKYKdBkgW6bJfFqYYXaDw4kupXBrXyMcJoU6Lc9Z",
-      "riotHandle": "@amigastaking:matrix.org"
+      "riotHandle": "@amigastaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 234,
       "name": "INFRASTRUCTURE CORPORATION/02",
       "stash": "D5aAp1y8XfkrmtPqsGFZtCjJrPZqKrsG2ceSha846jy6RMU",
-      "riotHandle": "@yayoi-v:matrix.org"
+      "riotHandle": "@yayoi-v:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 235,
       "name": "Bezerker",
       "stash": "H1SYKbpKYhUn46mQ3jJ6HLkKMzubA4j45gpmZ1tzo1cqzPx",
-      "riotHandle": "@hetairio:matrix.org"
+      "riotHandle": "@hetairio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 236,
       "name": "WildCousin-com 1",
       "stash": "EBj7AAN5Q3MsQiQwMdqH9Mp5RbeDAr2MTgFdkdgMSaq6ecn",
-      "riotHandle": "@wildcousin:matrix.org"
+      "riotHandle": "@wildcousin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 237,
       "name": "WildCousin-com 2",
       "stash": "HvoGhLEjW5SSzncjphZvey5KheeF89Byfku3CjKJP16edKp",
-      "riotHandle": "@wildcousin:matrix.org"
+      "riotHandle": "@wildcousin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 238,
       "name": "stakepile_2",
       "stash": "EAChfSL6tQfjy7vD8YgYB8DCn7A9c1aAsERP9Hx8cj1tqxL",
-      "riotHandle": "@stakepile:matrix.org"
+      "riotHandle": "@stakepile:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 239,
       "name": "Validatrium",
       "stash": "GNxLBL5TiXry4mWZmuDqmqj5JByWQkLr4sNP1RhF6Mo1HQ8",
-      "riotHandle": "@supermyzuk:matrix.org"
+      "riotHandle": "@supermyzuk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 240,
       "name": "Sik | crifferent(dot)de",
       "stash": "HWyLYmpW68JGJYoVJcot6JQ1CJbtUQeTdxfY1kUTsvGCB1r",
-      "riotHandle": "@dev0_sik:matrix.org"
+      "riotHandle": "@dev0_sik:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 241,
       "name": "United Stakes of Kusama 1",
       "stash": "CoPc18MiSdWM3DQTR6BYb8SqAVsKbjhYMd6oxQjENBMNX4k",
-      "riotHandle": "@unitedstakes:matrix.org"
+      "riotHandle": "@unitedstakes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 242,
       "name": "Khastor-KVN01",
       "stash": "D6NNbc18fTh4WVQtmrTyLRHGv8SKVtjKFY8uV34k5ydBMaV",
-      "riotHandle": "@khastor:matrix.org"
+      "riotHandle": "@khastor:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 243,
       "name": "kouti",
       "stash": "EAPMuky1KSMoBEY8YkA4dyN7yK3nLczzdodcKRJcXoQ7fCs",
-      "riotHandle": "@kouti:matrix.org"
+      "riotHandle": "@kouti:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 244,
       "name": "michalis/01",
       "stash": "GkmDg8scrddPXTuahbnU76GdAjjfJL6ESq1Nzs9uHQnSkyR",
-      "riotHandle": "@michalis:web3.foundation"
+      "riotHandle": "@michalis:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 245,
       "name": "mmagician-0",
       "stash": "DDufVxdkpbwuHYCnri1D4368MSNeXHQueA7AbhVG6r8jH1B",
-      "riotHandle": "@marcin:web3.foundation"
+      "riotHandle": "@marcin:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 246,
       "name": "mmagician-1",
       "stash": "HTpGQZf3Ea8b92oxmjRiSdfPPjU1Wy6kVVThZpdvnTCrF7P",
-      "riotHandle": "@marcin:web3.foundation"
+      "riotHandle": "@marcin:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 247,
       "name": "CryptoLab",
       "stash": "DBBFZxZqGPb2LSQSA4WHugerXGwm2ivywqdPxVnsJA9oyV3",
-      "riotHandle": "@jack77121:matrix.org"
+      "riotHandle": "@jack77121:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 248,
       "name": "inchainworks",
       "stash": "DbAdiLJQDFzLyaLsoFCzrpBLuaBXXqQKdpewUSxqiWJadmp",
-      "riotHandle": "@dafricash:matrix.org"
+      "riotHandle": "@dafricash:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 249,
       "name": "MoonBirdie 2",
       "stash": "Hke5YMJnUwo9BCctwSN8Mxy9Bcy6MXZJJ44YYmCDGqApZhk",
-      "riotHandle": "@moonbirdie:matrix.org"
+      "riotHandle": "@moonbirdie:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 250,
       "name": "Uno Staking 1",
       "stash": "HRfqVd1FL77o9EdYDZtooZ7cPxRx2xYvWnSe3YstKTGmJPK",
-      "riotHandle": "@unostaking:matrix.org"
+      "riotHandle": "@unostaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 251,
       "name": "Khastor-KVN02",
       "stash": "FwbSJotQLAyp7NANvtJESMmS1N921qW3bMQj4k2CqfNi4vf",
-      "riotHandle": "@khastor:matrix.org"
+      "riotHandle": "@khastor:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 252,
       "name": "United Stakes of Kusama 2",
       "stash": "GfFsEud27Ag4ngnZ1CehjYm7t6jJYauVV43ncssbfRVdTUK",
-      "riotHandle": "@unitedstakes:matrix.org"
+      "riotHandle": "@unitedstakes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 253,
       "name": "Liberty / Friedrich Hayek",
       "stash": "HeMh2BdLrgdE7g5Mu4Cx732FDe4SGLVrf2T2fAV82qaMSDU",
-      "riotHandle": "@blxxd:matrix.org"
+      "riotHandle": "@blxxd:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 254,
       "name": "Vires in Numeris",
       "stash": "HZZL1WsAkN8LLd1oFetTzxWGaz3kiVnDNmnC6gkeryBz5xp",
-      "riotHandle": "@viresnumeris:matrix.org"
+      "riotHandle": "@viresnumeris:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 255,
       "name": "Sonder",
       "stash": "CzFKweXiC853a3mrxJFbbmevZpT4i7Yy1iNuwdXZYm4wnqE",
-      "riotHandle": "@sondervalidation:matrix.org"
+      "riotHandle": "@sondervalidation:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 256,
       "name": "Aurora",
       "stash": "EK2yYS2xW96AGZaCn21Xcwdp5xzQVAe6VmoSpSYLg7ZvmmV",
-      "riotHandle": "@stakeaurora:matrix.org"
+      "riotHandle": "@stakeaurora:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 257,
       "name": "WEB3-SPACE | N01",
       "stash": "J7XHBQxacqTTVkoNoSgcG6CgREb9JVh2DHBbBQ1ycvkLBq4",
-      "riotHandle": "@web3-space:matrix.org"
+      "riotHandle": "@web3-space:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 258,
       "name": "al3c5",
       "stash": "G1AX3QgZyjAaNpMgTgnyY9uDgJAzezv84bxHZLgHevmpkVZ",
-      "riotHandle": "@1l3c5:matrix.org"
+      "riotHandle": "@1l3c5:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 259,
       "name": "lunar_dot_2",
       "stash": "GNYcq54aXW3PuZ6mJnNzuV9AfYrJhL7HJ5svCEzn1XTuov8",
-      "riotHandle": "@lunar_dot:matrix.org"
+      "riotHandle": "@lunar_dot:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 260,
       "name": "inchainworks-00",
       "stash": "FoHbtrqtsrDct1ojC5zW2hB1rtyKp6cc7RLa7TeUyib5Z7i",
-      "riotHandle": "@rkyasss:matrix.org"
+      "riotHandle": "@rkyasss:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 261,
       "name": "Amforc AG 6",
       "stash": "J9KLy6nouPoj5rA2RWX8C9wrmrg84Mv3hpB7mZTN7Jvww7C",
-      "riotHandle": "@tugytur:matrix.org"
+      "riotHandle": "@tugytur:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 262,
       "name": "Amforc AG 7",
       "stash": "Czy1KnZV1DqSPcHd6k1WL6fe4nsyhAuiJ9ALZtVvyomdc8y",
-      "riotHandle": "@tugytur:matrix.org"
+      "riotHandle": "@tugytur:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 263,
       "name": "***GuardaValidatorNode***",
       "stash": "GF8aMvrAPMo3WGvQ9DcdSXSSBfZ16HXycgoCKsZ3QUQTTse",
-      "riotHandle": "@guarda:matrix.org"
+      "riotHandle": "@guarda:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 264,
       "name": "bravebat-kusama-1",
       "stash": "Gve4JFfF5YkZJNwKTbRVTQCkLXJJhzjJszJjxPvHLb9fho5",
-      "riotHandle": "@bravebat:matrix.org"
+      "riotHandle": "@bravebat:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 265,
       "name": "anb_kusama1",
       "stash": "E4JgAkN3sz4wDG33egGGsCJMu23nzQXrvSLTsFrzFuikbHd",
-      "riotHandle": "@anubidigital:matrix.org"
+      "riotHandle": "@anubidigital:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 266,
       "name": "Amiga Staking 1",
       "stash": "EPxk4HQnX3jUEwPbBZJH7J5c1gt8KRsHZxjw5tTWqsygXm5",
-      "riotHandle": "@amigastaking:matrix.org"
+      "riotHandle": "@amigastaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 267,
       "name": "nodamatics-polkadot-kusama-validator-17-0",
       "stash": "GxuEngysAC4a5SZX9w7eTVY4iye8RRxVVXbzfSxXzJ8Nf3Y",
-      "riotHandle": "@andrey.kouznetsov:nodamatics.com"
+      "riotHandle": "@andrey.kouznetsov:nodamatics.com",
+      "kyc": false
     },
     {
+      "slotId": 268,
       "name": "all4hodler",
       "stash": "FZoQT3t8t4H8LRKqb1pe34UJbeEbtVstzUB7xm4ra2DWdfq",
-      "riotHandle": "@all4hodler:matrix.org"
+      "riotHandle": "@all4hodler:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 269,
       "name": "Pi | π",
       "stash": "EYACaN7kNiANNDRde6WQvHoTmwUqxnR8tUBCw2jDF3dX54t",
-      "riotHandle": "@Investiq:matrix.org"
+      "riotHandle": "@Investiq:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 270,
       "name": "all4hodler-v1",
       "stash": "DzGfdX9G594Txpo7skHw3GgKjFTE9CrRPfXQ2VdRpYPbS6S",
-      "riotHandle": "@all4hodler:matrix.org"
+      "riotHandle": "@all4hodler:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 271,
       "name": "anb_kusama2",
       "stash": "ELuVvnp16AqbCKFZmwMsZSFEV4hGgQLRRxTYtqTkiRyLw65",
-      "riotHandle": "@anubidigital:matrix.org"
+      "riotHandle": "@anubidigital:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 272,
       "name": "STK CENTER",
       "stash": "HsoF56BFCDgvWtuJ8TcmMgvJ6QTRfWwJauRuUM13qRFfQpp",
-      "riotHandle": "@stk.center:matrix.org"
+      "riotHandle": "@stk.center:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 273,
       "name": "Taiwan 002",
       "stash": "CwTzXx7Ga3CuFzJSbc4xHphY3dryFxAHwno1DR7o2tPKpAg",
-      "riotHandle": "@yaohsin:matrix.org"
+      "riotHandle": "@yaohsin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 274,
       "name": "freedom",
       "stash": "EQF1HnQhSHRqfFEc5aReFHpKZDwkDP8F1WACQ1nN7TGopeV",
-      "riotHandle": "@connecteconomy:matrix.org"
+      "riotHandle": "@connecteconomy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 275,
       "name": "🍀LuckyFriday-KSM-09🍀",
       "stash": "EdRPifdGyiFPkTz6wPkSJoUKMua4cz7tqy5HYgXtwsUm6M2",
-      "riotHandle": "@luckyfriday:matrix.org"
+      "riotHandle": "@luckyfriday:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 276,
       "name": "Kinematiks Labs ⚗️",
       "stash": "E2TtDRDYdHRDXAoB7WYivEEWh5EdfRjUryQ574Up1cmKBMQ",
-      "riotHandle": "@cetin:matrix.org"
+      "riotHandle": "@cetin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 277,
       "name": "al3c5-2",
       "stash": "G5hwBggY54Bm3hSo1wgrsTwkXuDkD5Juh73R6PiGGEmo1PS",
-      "riotHandle": "@1l3c5:matrix.org"
+      "riotHandle": "@1l3c5:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 278,
       "name": "❄❄❄️",
       "stash": "DyxpaKdwEUP5XCN4Jme11hVRLu87AqKz2q1xBH9xNKzmirx",
-      "riotHandle": "@icecoldnat:matrix.org"
+      "riotHandle": "@icecoldnat:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 279,
       "name": "LoganTG02",
       "stash": "D8cKfwmQDrQMTAQgHseH6ysLXH4BY9hRBzvQ3bbVuMxXpam",
-      "riotHandle": "@logantg:matrix.org"
+      "riotHandle": "@logantg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 280,
       "name": "Zizzle-KUS-Validator",
       "stash": "GFTBZ1p9UFfn662hdbE84R9FFSkW1wHqyV8N2t27gW1fh8U",
-      "riotHandle": "@zizzle:matrix.org"
+      "riotHandle": "@zizzle:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 281,
       "name": "Zizzle-KUS2-Validator",
       "stash": "GwGCd3XM5qCExnPJT6wyAqygNRZQL9Tqta3txfswnUsEJWr",
-      "riotHandle": "@zizzle:matrix.org"
+      "riotHandle": "@zizzle:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 282,
       "name": "3080ra",
       "stash": "Cg8yN3VucSgk15boaYbFe1mUAybhD8Znh8mnk1PN43SfLZn",
-      "riotHandle": "@3080ra:matrix.org"
+      "riotHandle": "@3080ra:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 283,
       "name": "🍀LuckyFriday-KSM-08🍀",
       "stash": "GM31KcErdS3ob8wmFSbLycccJ6YGvvTXLBAawd6d9wkAxqj",
-      "riotHandle": "@luckyfriday:matrix.org"
+      "riotHandle": "@luckyfriday:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 284,
       "name": "staking-lab",
       "stash": "DqJWygp9DwGM6xi31Z11PxZKcg4xNfKQsxWK6NPJmSXBnmF",
-      "riotHandle": "@stakinglab:matrix.org"
+      "riotHandle": "@stakinglab:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 285,
       "name": "bravebat-kusama-2",
       "stash": "JFLU9RLRu7QXKgBsASwUpaFFbfRUrndoujMJsCeKxkvpDUV",
-      "riotHandle": "@bravebat:matrix.org"
+      "riotHandle": "@bravebat:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 286,
       "name": "Berlin | validierung_cc 🇩🇪",
       "stash": "GHd1brgDS29LhSUMYSorgEWFb2n1M3H4EMz6mcpt8TTdHho",
-      "riotHandle": "@kev.funke:matrix.org"
+      "riotHandle": "@kev.funke:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 287,
       "name": "coldstoragecapital1",
       "stash": "DcfRKn9yjeGtLofq2bSfxqJUMd31ia4mqRRwRLcu7ACC389",
-      "riotHandle": "@coldstoragecapital:matrix.org"
+      "riotHandle": "@coldstoragecapital:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 288,
       "name": "coldstoragecapital2",
       "stash": "DVf4yfvkWHWEBxizjFatabq7yfrLW4vuv7HcV7RCsusQP6Q",
-      "riotHandle": "@coldstoragecapital:matrix.org"
+      "riotHandle": "@coldstoragecapital:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 289,
       "name": "spaceman116",
       "stash": "GbmW3q2Hv5UaiRreQuBtevXb8DHdvsRFkBGXe2Xz1Y9FM8a",
-      "riotHandle": "@spaceman116:matrix.org"
+      "riotHandle": "@spaceman116:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 290,
       "name": "🐍snakestake🐍",
       "stash": "HG1dCdm3oBZVppZijoCfT3hVygPaEeYLrJRgHt3bU4YQ5yy",
-      "riotHandle": "@snakestake:matrix.org"
+      "riotHandle": "@snakestake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 291,
       "name": "PressburgLabs-stake-02",
       "stash": "EygmNkGy9vnTsM3wkHLYBt212TJPLDDptVQxuhfihggdkTY",
-      "riotHandle": "@pressburglabs:matrix.org"
+      "riotHandle": "@pressburglabs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 292,
       "name": "🍁 HIGH/STAKE 🥩 | HEL1-KSM",
       "stash": "DbRgw96nMQcFEFZWTLd6LSPNdh8u3NBuUDfAhDmB6UU8cJC",
-      "riotHandle": "@highstake:matrix.org"
+      "riotHandle": "@highstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 293,
       "name": "POKU-KSM-1",
       "stash": "HHxJGYkkxzYNpDmoGomwuGBc8mtZQDhyhvWiCgUpJttpR1K",
-      "riotHandle": "@poku_node:matrix.org"
+      "riotHandle": "@poku_node:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 294,
       "name": "CryptoProcessing_io",
       "stash": "DYptDHaihsVHDHnSPRHNnkM2u5RuaSQdBXR9Ch3XZQDoffR",
-      "riotHandle": "@cryptoprocessing:matrix.org"
+      "riotHandle": "@cryptoprocessing:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 295,
       "name": "Berezka",
       "stash": "EVgkDV9X4BmnMi3ZNgrkKW3WEiaZ6wqE1HVRZziNnERmyfi",
-      "riotHandle": "@tiktak34:matrix.org"
+      "riotHandle": "@tiktak34:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 296,
       "name": "sensei-bra",
       "stash": "DiCVJt4fNZTmsxRSi7J3dDVMTDsCV7k9BG9ray5Yt5WJoMD",
-      "riotHandle": "@jchitty:matrix.org"
+      "riotHandle": "@jchitty:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 297,
       "name": "SPBDrink",
       "stash": "E7yeQXKWCg9XxjVMZULJNrFBgzSBLRpHoPGcE9Z1M7jC5c8",
-      "riotHandle": "@spbdrink:matrix.org"
+      "riotHandle": "@spbdrink:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 298,
       "name": "Varejka",
       "stash": "DPuG89deqMcPAbPBYsbonzFrMAzZgTmBxmMNuH5LiQxcu7X",
-      "riotHandle": "@varejka:matrix.org"
+      "riotHandle": "@varejka:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 299,
       "name": "STAKECRAFT",
       "stash": "HKzQetwesWrSoCwidmTFxTDKhvGTtstXBSeWoZYeMtipdVH",
-      "riotHandle": "@n1trog3n:matrix.org"
+      "riotHandle": "@n1trog3n:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 300,
       "name": "CS_Axial",
       "stash": "DMNWV5U4GHvc28LNbYzckpPqihSqSu6C4WnKQWgSXbZqwJy",
-      "riotHandle": "@lilialul:matrix.org"
+      "riotHandle": "@lilialul:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 301,
       "name": "MC-Kusama1",
       "stash": "GLdbdQ1E5kM73RN6d8Z1SW7auyneEpp99rxp49ziDaz535B",
-      "riotHandle": "@mc_:matrix.org"
+      "riotHandle": "@mc_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 302,
       "name": "EK-Kusama1",
       "stash": "DZzMSwXzbxhnCJePpzRKs1GD3yX25LP91y2Q9kFmPHXQ1vY",
-      "riotHandle": "@plasmajack:matrix.org"
+      "riotHandle": "@plasmajack:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 303,
       "name": "turboflakes-2",
       "stash": "GwJweN3Q8VjBMkd2wWLQsgMXrwmFLD6ihfS146GkmiYg5gw",
-      "riotHandle": "@turboflakes:matrix.org"
+      "riotHandle": "@turboflakes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 304,
       "name": "Paramito-KV2",
       "stash": "EBd9PDnKJHkL3r5yu8Yw7VWNj7ARSxTCXi2FLQvqhcVtd1o",
-      "riotHandle": "@paramito:matrix.org"
+      "riotHandle": "@paramito:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 305,
       "name": "RadiumBlock-Kusama",
       "stash": "EwR2jzx7gZSjxCXbkVZRm39W2fWGJtwXYYftQYdVfcJjtt4",
-      "riotHandle": "@radiumblock:matrix.org"
+      "riotHandle": "@radiumblock:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 306,
       "name": "TWOPBL_KA02",
       "stash": "J6HHWeSmt5PjoDCRzVvB5oJnQMMvCM5iNBd5W42S8L3BbVK",
-      "riotHandle": "@generic-chain:matrix.org"
+      "riotHandle": "@generic-chain:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 307,
       "name": "vertex",
       "stash": "GMdKDQYpi6j2px524iP2yGvd9GHDdwuZr3HyBnBFmygeboj",
-      "riotHandle": "@thevertex:matrix.org"
+      "riotHandle": "@thevertex:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 308,
       "name": "GATOTECH😸KSM_1",
       "stash": "DrRBkx2Qx4sXRGZDXz6d44QCXqV2eJhn8Rq79V88FpSqAr8",
-      "riotHandle": "@gatotech:matrix.org"
+      "riotHandle": "@gatotech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 309,
       "name": "1kvnode9054-001",
       "stash": "GA5erzqBdjwjacEoK6bMK6PNz2orc74bNbf3ZzaePdQYTkw",
-      "riotHandle": "@dave44:matrix.org"
+      "riotHandle": "@dave44:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 310,
       "name": "TWOPBL_KA04",
       "stash": "HLob9M4rBKGcKCtkeqQfuzMJj737r4KJaAnddWLg5ByXCU6",
-      "riotHandle": "@generic-chain:matrix.org"
+      "riotHandle": "@generic-chain:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 311,
       "name": "CapitalStaking01",
       "stash": "DBdn3d5cWg8yfa3u7LsJdjxyrGxNfWoieWdrNGGrsivmbZk",
-      "riotHandle": "@capital_staking:matrix.org"
+      "riotHandle": "@capital_staking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 312,
       "name": "CapitalStaking02",
       "stash": "H1LZZkqyYFv28bjP3HcGM5RdAEoCGFEuA8tHdfLGwwGw73t",
-      "riotHandle": "@capital_staking:matrix.org"
+      "riotHandle": "@capital_staking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 313,
       "name": "nodamatics-polkadot-kusama-validator-16-0",
       "stash": "EwaMZ7Qt9iuGPXEV1N39784XhhBVSepE9EUfEsbhLwTncZo",
-      "riotHandle": "@andrey.kouznetsov:nodamatics.com"
+      "riotHandle": "@andrey.kouznetsov:nodamatics.com",
+      "kyc": false
     },
     {
+      "slotId": 314,
       "name": "Vegas_life_main-DO/2",
       "stash": "GnqygxyvFN7npYbMUv6t7avBnLrVB37topoDbhPVnBeeuxa",
-      "riotHandle": "@ccris02:matrix.org"
+      "riotHandle": "@ccris02:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 315,
       "name": "RadiumBlock-Kusama2",
       "stash": "HC2sAUQ9X2B8wbknBWRVUi9kpCJ7fjvwqahysmSRoLvFsWS",
-      "riotHandle": "@radiumblock:matrix.org"
+      "riotHandle": "@radiumblock:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 316,
       "name": "Elenode",
       "stash": "GPeAgenYP4rngtRtFufgCcn3oezWRRHgzCPJUSSqbNfxFkm",
-      "riotHandle": "@elentronix:matrix.org"
+      "riotHandle": "@elentronix:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 317,
       "name": "Infinity",
       "stash": "GPTwmqixpfnum8jCBVmYBYnseb8q6g9b4kxWRRuuRTAqMoX",
-      "riotHandle": "@zeb09:matrix.org"
+      "riotHandle": "@zeb09:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 318,
       "name": "validator_tesla",
       "stash": "HTyzs9XAxUpHpNe7Kwhp3M5kCJuxFm4AYRCpYjcHdhiVDFE",
-      "riotHandle": "@jan_tsl:matrix.org"
+      "riotHandle": "@jan_tsl:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 319,
       "name": "🍀ARISTOPHANES🍀",
       "stash": "HU6TSsvA84GKrTiyArBHiFDVBSLHNr5Ki3qPV7T8WKyVJaz",
-      "riotHandle": "@pythagoras.c.i:matrix.org"
+      "riotHandle": "@pythagoras.c.i:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 320,
       "name": "anovernode",
       "stash": "FFQzhqbCaYKMxuETSvKh3afQQTTE8ijNTzVnVTg4KTu7vqh",
-      "riotHandle": "@paride_f:matrix.org"
+      "riotHandle": "@paride_f:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 321,
       "name": "Mass Stake - Kusama",
       "stash": "F4sqPppPjsxNfv3tqE5E8CixuouV83qvWeCKigyKqWLUXuQ",
-      "riotHandle": "@embiei:matrix.org"
+      "riotHandle": "@embiei:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 322,
       "name": "COSMOTRON",
       "stash": "EVhWhw6w6i5C9SV3FbHdM1rroTxsM5UzxEKMyXCwnct2EnH",
-      "riotHandle": "@cosmotronv:matrix.org"
+      "riotHandle": "@cosmotronv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 323,
       "name": "decentraDOT3",
       "stash": "HqF6t7B84v2XTbAC4VZmjsyQhvRUJrcCdUPAYVCpYru32SU",
-      "riotHandle": "@arthurhoeke:matrix.org"
+      "riotHandle": "@arthurhoeke:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 324,
       "name": "Antrome",
       "stash": "DPoJe9z9k36jJpCj32K6m2eT6DAnwvkrUsUkXHnRXWiEuyY",
-      "riotHandle": "@antrome:matrix.org"
+      "riotHandle": "@antrome:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 325,
       "name": "Phoenix",
       "stash": "Dmkww4FsXG3gjCTdpuyAXxfKWtXfYcxV1VJfy7JyPxvjUPA",
-      "riotHandle": "@pho45:matrix.org"
+      "riotHandle": "@pho45:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 326,
       "name": "LLoyds Tech",
       "stash": "J12kKQz1qcCHBg36Txz2k9mNKYERhjKRRSshwUghT11medm",
-      "riotHandle": "@lloyds.tech:matrix.org"
+      "riotHandle": "@lloyds.tech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 327,
       "name": "Annval",
       "stash": "HTiHYfSRCkUn5u58KRHWjkNPRPP1MNahuXdEr2TtJ5xXfZU",
-      "riotHandle": "@annval:matrix.org"
+      "riotHandle": "@annval:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 328,
       "name": "Cypher Labs",
       "stash": "Ht1XzYWEGnLpFwJiRnj6uvtcYqK1fbeL5Us8Z2rkeoCK6Wx",
-      "riotHandle": "@fred3ric:matrix.org"
+      "riotHandle": "@fred3ric:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 329,
       "name": "ProofOfTrue/2",
       "stash": "CpRu1U13GaBdSxd4tqw3jjCGCpRgte5v8sLkaXcqtzAxFRG",
-      "riotHandle": "@verstak:matrix.org"
+      "riotHandle": "@verstak:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 330,
       "name": "1kvnode9054-002",
       "stash": "E2TW64quCycBc43q5xcu3h1m3eMGGijN7CFHYvSh9KzZVwA",
-      "riotHandle": "@dave44:matrix.org"
+      "riotHandle": "@dave44:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 331,
       "name": "PressburgLabs-stake-01",
       "stash": "EctdZvgkphLJMQmKntaPP74LKpGvDKaj1cbqC8fUT4HzqiC",
-      "riotHandle": "@pressburglabs:matrix.org"
+      "riotHandle": "@pressburglabs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 332,
       "name": "BEREZKA2",
       "stash": "FtbEoFRHt2K8kFBwVZsJzwmwEF5rnC5ZvwCphTe64fGUAk4",
-      "riotHandle": "@tiktak34:matrix.org"
+      "riotHandle": "@tiktak34:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 333,
       "name": "==ELDORADO-Validator2==",
       "stash": "F358tdKgqzU2YivnRVVZT7QgyScfPWR66c55YvLq4zeQvih",
       "riotHandle": "@paul-gie:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 334,
       "name": "Kusama XI Validator 2",
       "stash": "DKKax6uZkiNPfd2ATd8cJhyi3c1KZD24VDdoWG9CfTmwgSp",
-      "riotHandle": "@hitchhooker:matrix.org"
+      "riotHandle": "@hitchhooker:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 335,
       "name": "GATOTECH😸KSM_2",
       "stash": "EeFYYF8zrLXRpfFXLn2T5bMmgiFpDpmAhVzoh9hA3188wTc",
-      "riotHandle": "@gatotech:matrix.org"
+      "riotHandle": "@gatotech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 336,
       "name": "LEPRECHAUN2",
       "stash": "EXmDBkb8K1bVrUqjVxNmE9VhB96M39ES4d8QdbAij3rast7",
-      "riotHandle": "@polkaleprechaun:matrix.org"
+      "riotHandle": "@polkaleprechaun:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 337,
       "name": "VAREJKA_L",
       "stash": "FqoPGAqaZWBWAmKTX7mAToCv8aV3mqqgxiSNE9kKRLWuEC7",
-      "riotHandle": "@varejka:matrix.org"
+      "riotHandle": "@varejka:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 338,
       "name": "🍀ARISTOPHANES2🍀",
       "stash": "JHbMAHJw6nnQPD3Zth13DGoPxLjYUPWC71AMbErt817nK9y",
-      "riotHandle": "@pythagoras.c.i:matrix.org"
+      "riotHandle": "@pythagoras.c.i:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 339,
       "name": "Bluefin_Tuna2",
       "stash": "DBfT2GUqHX89afMhTzGCCbAc44zX33d4XySWX2qAPxZ35KE",
-      "riotHandle": "@bluefin_tuna:matrix.org"
+      "riotHandle": "@bluefin_tuna:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 340,
       "name": "ExPeCtCHaoS-COM 210",
       "stash": "DmvZCJHgQGcEF267fvFHvVE4nYbqDGvVfmTP1QsgPrFnkdH",
-      "riotHandle": "@steak-king:matrix.org"
+      "riotHandle": "@steak-king:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 341,
       "name": "Genesis Lab /2",
       "stash": "DPc3YPyWts9LjqBUy7hhLDwN4iHPXU6vicURDMYAMqnW5gi",
-      "riotHandle": "@i7495:matrix.org"
+      "riotHandle": "@i7495:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 342,
       "name": "STAKECRAFT2",
       "stash": "EQNMpUBms7Ht9AGSCxpyvzEwiBuSzm4HbzUqfKd8Adcc44p",
-      "riotHandle": "@n1trog3n:matrix.org"
+      "riotHandle": "@n1trog3n:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 343,
       "name": "Ancibanci-2",
       "stash": "CaNcZBjbvPWXVFAxtAGLBwk2iEEAU6kAJFHyc4Kc2XWmKuj",
-      "riotHandle": "@ancibanci:matrix.org"
+      "riotHandle": "@ancibanci:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 344,
       "name": "NOVOSIB",
       "stash": "Di33zuZw5LxLUhg5JU7bLuPrhn1R921su51LabLyYPhM2MP",
-      "riotHandle": "@novosib:matrix.org"
+      "riotHandle": "@novosib:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 345,
       "name": "1 Future",
       "stash": "JEfXUjhjjnb2RZmuthXjDGAf34T1SndetNB5gN1uJZ1372C",
-      "riotHandle": "@1futu:matrix.org"
+      "riotHandle": "@1futu:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 346,
       "name": "YARIK",
       "stash": "GPXThfrRtVwyLu5q788nq9zUiKVRHwX4z6quSdN2vRg1Ww4",
-      "riotHandle": "@yarikslovo:matrix.org"
+      "riotHandle": "@yarikslovo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 347,
       "name": "DrBlock",
       "stash": "EDn3kJUUwKNZp7nvm2dxbz8QrPm3BxKRMnpipn2m9PQUvmB",
-      "riotHandle": "@maxbookpro:matrix.org"
+      "riotHandle": "@maxbookpro:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 348,
       "name": "decentraDOT2",
       "stash": "Em4HYqVrWX3uCvrC8NWoabfKpV9z8stdRKkXYXcZdWGxdXT",
-      "riotHandle": "@arthurhoeke:matrix.org"
+      "riotHandle": "@arthurhoeke:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 349,
       "name": "Monin Staking | Kusama",
       "stash": "GnYphGafcY6d12Js6e23R9CohEjicUbarggcz2qBQtrzdwD",
-      "riotHandle": "@marc_monin:matrix.org"
+      "riotHandle": "@marc_monin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 350,
       "name": "TX1",
       "stash": "EtuN1h92gaV961S15PwxN6GHyeonaojALZ8Dddgn1oDPRFt",
-      "riotHandle": "@olegan_:matrix.org"
+      "riotHandle": "@olegan_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 351,
       "name": "JJB-KSM-Validator",
       "stash": "F2mwdEWtgnD7EC5AfKbT5PpYmChFx2bbBRtpDBJgrZkRLLz",
-      "riotHandle": "@jjbweb3:matrix.org"
+      "riotHandle": "@jjbweb3:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 352,
       "name": "lets_node",
       "stash": "DpH13oY6Gp9ca1jedmw1BEvqbD9jAuFoifLbL1BahWoaH6o",
-      "riotHandle": "@lets_node:matrix.org"
+      "riotHandle": "@lets_node:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 353,
       "name": "Babes Papes",
       "stash": "ESJW7WgAxoybpZ6ULrh6dYwi3WpEGY2hN3wB1eYKE3NcTHo",
-      "riotHandle": "@babespapes:matrix.org"
+      "riotHandle": "@babespapes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 354,
       "name": "Zedazi Capital 01",
       "stash": "CywgPP43C4yVNGipBPR5QohWjuLZSPK8ubHthHBHzksXPtg",
-      "riotHandle": "@zedazi:matrix.org"
+      "riotHandle": "@zedazi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 355,
       "name": "Zedazi Capital 02",
       "stash": "EMakvqLq3K77WzFufbepR9AyCjkJs6cZeaZjGyADiTtsDPH",
-      "riotHandle": "@zedazi:matrix.org"
+      "riotHandle": "@zedazi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 356,
       "name": "2 Future",
       "stash": "HsbGKG6hvKvYk2SF8vug4LEjBV18kh3Cr52MABwDQd4BuBM",
-      "riotHandle": "@1futu:matrix.org"
+      "riotHandle": "@1futu:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 357,
       "name": "cryptobees-validator-2",
       "stash": "HJRLKPrL6m8gcTHY9z2hJvg8etDbT99rEpZfeT9nmWi9xA1",
-      "riotHandle": "@cryptobee:matrix.org"
+      "riotHandle": "@cryptobee:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 358,
       "name": "E-KAT",
       "stash": "DzF1mzay4Nm1vepKtMWAAMaxZeovTjCZEzBLEx6J7Bnf4bd",
-      "riotHandle": "@e_k_a_t:matrix.org"
+      "riotHandle": "@e_k_a_t:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 359,
       "name": "sakura",
       "stash": "EVTgjzPPHrQwVx97dc7p55hYkVdW6is1mzMr1kacHpkZDTQ",
-      "riotHandle": "@sakuratech:matrix.org"
+      "riotHandle": "@sakuratech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 360,
       "name": "PDP_Validator2",
       "stash": "HCogweijHTm85qf9cSUqjNmyZZvu61r4SsTcsAT7S7pgpem",
-      "riotHandle": "@paveldp:matrix.org"
+      "riotHandle": "@paveldp:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 361,
       "name": "NOVOSIB2",
       "stash": "H6dMn25SiAcdKujQnTuUvg4fPsWUDZrw6Wt5jteuGxbtwoD",
-      "riotHandle": "@novosib:matrix.org"
+      "riotHandle": "@novosib:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 362,
       "name": "MAMA_KUSAMA",
       "stash": "DpEBgXSmcUG6nbbCnS6pk4Nd9fvkoG4axBiw4EqJPQkqr3V",
-      "riotHandle": "@nastasiya:matrix.org"
+      "riotHandle": "@nastasiya:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 363,
       "name": "Mass Stake – Kusama#2",
       "stash": "GAfMi2CLf1wHXRkbSbm3g2dB8H4aGYqfQaZBwujnAtxdAGx",
-      "riotHandle": "@embiei:matrix.org"
+      "riotHandle": "@embiei:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 364,
       "name": "☉ lux8_net - 02 ☉",
       "stash": "Dom3VWEQu8JNePDhX3Ce581eVLK77rSdBbqDLtRb5ZWHV31",
-      "riotHandle": "@ama31337:matrix.org"
+      "riotHandle": "@ama31337:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 365,
       "name": "VLADIMIR ",
       "stash": "HUE5nUANxvCRW7SoLAHcKdB2PLoUpUVyuSdviHrKKQAV5EC",
-      "riotHandle": "@gratevladimir:matrix.org"
+      "riotHandle": "@gratevladimir:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 366,
       "name": "SunshineAutos",
       "stash": "HvCKgQnApvzKJPLc73VSaRhpGFmeQaEyZ4Dbcnj5dJyE6AS",
-      "riotHandle": "@sunshineautosnodes:matrix.org"
+      "riotHandle": "@sunshineautosnodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 367,
       "name": "PimeTaradox",
       "stash": "Hgjqt5NUcKzNckgz23xfaJL89onmvmTrywZ6xH5FhY7LfKG",
-      "riotHandle": "@pimetaradox:matrix.org"
+      "riotHandle": "@pimetaradox:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 368,
       "name": "Sik 2 | crifferent(dot)de",
       "stash": "GLSikJaXTVWvWtUhzB3Bj6xb5TcnhTUp6EuAkxaCohT9UBv",
-      "riotHandle": "@dev0_sik:matrix.org"
+      "riotHandle": "@dev0_sik:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 369,
       "name": "DotSkull-KSM",
       "stash": "EUYfsTNCCVJbrq7YjT4xbxWB8GX1j7nRZiuziQVj9mjFSdP",
-      "riotHandle": "@dotskull:matrix.org"
+      "riotHandle": "@dotskull:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 370,
       "name": "YARIK2",
       "stash": "DDuHcFtsAaJyk3RxXJGybN3icx95TouqLYF5jjb1Uqnvwtg",
-      "riotHandle": "@yarikslovo:matrix.org"
+      "riotHandle": "@yarikslovo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 371,
       "name": "STRAWBERRY-STAKING",
       "stash": "FZfG7K9Yx7qwHHV9xnaUhnxeUziSCHmcB6K5THZaGuuTdXw",
-      "riotHandle": "@sweetberry:matrix.org"
+      "riotHandle": "@sweetberry:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 372,
       "name": "⛰ HELIKON ⛰ GALATA",
       "stash": "Gfwy4tGZvCnKmwQDE1tHjGPNY2LDqezW6bPY4mYMrrjiWnE",
-      "riotHandle": "@helikon:matrix.org"
+      "riotHandle": "@helikon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 373,
       "name": "vinci🇫🇷",
       "stash": "GsW7NAUcWMQ92Ata4QjJ1vNHN3PrgvUbLe5T2RXtjxvUXLL",
-      "riotHandle": "@gauth8z:matrix.org"
+      "riotHandle": "@gauth8z:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 374,
       "name": "StakePool247",
       "stash": "HUEwe3LgEdPW3HkUNAcYYq9EbbaoV3L3gUKbiTsPr4mccMW",
-      "riotHandle": "@stakepool247:matrix.org"
+      "riotHandle": "@stakepool247:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 375,
       "name": "STAKE-QUEEN",
       "stash": "HHHyHUy3kKpWQt2o47NdDxHAPHg6rXMHsAZjCSbS5rvpStY",
-      "riotHandle": "@queenpersot:matrix.org"
+      "riotHandle": "@queenpersot:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 376,
       "name": "Ice",
       "stash": "JKzwkX6JcARutZvJpArnUFZnYnbsZedCTJfbhrqTtPuxezU",
-      "riotHandle": "@zar1:matrix.org"
+      "riotHandle": "@zar1:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 377,
       "name": "DARK-KUSAMA",
       "stash": "JCHVzJjBWS1ZxkTZJN1jifYrDcspepCU2YCW23XhtVQnYE7",
-      "riotHandle": "@darkless2001:matrix.org"
+      "riotHandle": "@darkless2001:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 378,
       "name": "ksm-moon-1",
       "stash": "Hpf7KTh2LmZiGQe3qaahVsMN8LSak1UFMgSJtUdDHpSiqjU",
-      "riotHandle": "@ksmoon:matrix.org"
+      "riotHandle": "@ksmoon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 379,
       "name": "🍁 HIGH/STAKE 🥩 | ZRH1-KSM",
       "stash": "HQuPha82sRy91zZn73XRGJVV3ernBh5HZKftUcoDT8CSUwK",
-      "riotHandle": "@highstake:matrix.org"
+      "riotHandle": "@highstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 380,
       "name": "Saturn V",
       "stash": "Gtbui8rCwSBKn3v2RdmD2z7TKUCnCChtARmTwQi34ngGZmK",
-      "riotHandle": "@bulrog:matrix.org"
+      "riotHandle": "@bulrog:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 381,
       "name": "STKD",
       "stash": "Fq4YmiAq76DntjMKKjMiL98MYszoApUa9idSErvyzfdGoqG",
-      "riotHandle": "@frazzled:matrix.org"
+      "riotHandle": "@frazzled:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 382,
       "name": "MAMA_KUSAMA_2",
       "stash": "FqY3mdSf8ZxcBVvjzkbBLgP3XLbA2ikPrExtiWFpidkjPct",
-      "riotHandle": "@nastasiya:matrix.org"
+      "riotHandle": "@nastasiya:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 383,
       "name": "WOLF_STAKING",
       "stash": "FUyY55mx5zavpkETx3Na9wi421eJ7rhijoRmXWNCBHUik8Q",
-      "riotHandle": "@peterkevins:matrix.org"
+      "riotHandle": "@peterkevins:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 384,
       "name": "Crypto-builder",
       "stash": "FtYSnTCie4oeHD1mXwTFAeYPhKjg5JmQxQBAppBV1oxq4Sr",
-      "riotHandle": "@antonio.crypto:matrix.org"
+      "riotHandle": "@antonio.crypto:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 385,
       "name": "GalaxyNode",
       "stash": "ComC1bkQiVoFgEJ6RkdRM9R6akikye4Ldbk1orj2grp55hp",
-      "riotHandle": "@galaxymen:matrix.org"
+      "riotHandle": "@galaxymen:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 386,
       "name": "STAKE-QUEEN2",
       "stash": "DGm5ntY1Cifr427BKhFXtVyCgxEW7cbg7xqX7Y8pEYaGt3c",
-      "riotHandle": "@queenpersot:matrix.org"
+      "riotHandle": "@queenpersot:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 387,
       "name": "ksm-moon-2",
       "stash": "GEw8S2PmLaoU5hR8uR6Mjczhr36gPb6ZYLiYb9h74e7bSa2",
-      "riotHandle": "@ksmoon:matrix.org"
+      "riotHandle": "@ksmoon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 388,
       "name": "NQ4",
       "stash": "HbnDhMBcrVe9jFgHQT96LKvuEQgxArFm9dkdvxE2kSaqroS",
-      "riotHandle": "@nq4:matrix.org"
+      "riotHandle": "@nq4:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 389,
       "name": "KobreDabre",
       "stash": "FSRywMqAT92LJ8ihaQ7w1N8dXvLau53nEQx3EmNdGns2QAY",
-      "riotHandle": "@kobredabre:matrix.org"
+      "riotHandle": "@kobredabre:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 390,
       "name": "Kusamica Zgabica",
       "stash": "Fktq9ciMBhSnx4MJbaQqgy651HXpdJLLKDJH4Ahy2yEbrv2",
-      "riotHandle": "@bulrog:matrix.org"
+      "riotHandle": "@bulrog:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 391,
       "name": "Ciechom",
       "stash": "FEXzBjYFzPMPxYSP7ym1WZZ865brUUHqPpdVNpY9Lzqh5kK",
       "riotHandle": "@c13ch0m:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 392,
       "name": "Lightning Blocks",
       "stash": "FMR23WhgV6gW935sjJdvnxT733oaPbBdrkCgurt5AR6JTAj",
-      "riotHandle": "@lightningblocks:matrix.org"
+      "riotHandle": "@lightningblocks:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 393,
       "name": "lucasyoda01",
       "stash": "Hho7Xp7bHs4qmJjoPAcAac4YT61DwH1UwhfY7MQWWeWsF8R",
-      "riotHandle": "@lucasyoda:matrix.org"
+      "riotHandle": "@lucasyoda:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 394,
       "name": "WOLF_STAKING2",
       "stash": "HRvhZa1T6WwApvJrjiiqLf3W5WfjggoU9664pWxEpYNcXdS",
-      "riotHandle": "@peterkevins:matrix.org"
+      "riotHandle": "@peterkevins:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 395,
       "name": "snf-ksm-validator",
       "stash": "FHrTpbgYUARAmzUiSYqcRjDbCAQ6rqJBbMnKjvNoakNqu2S",
-      "riotHandle": "@ihubanov:matrix.infosec-consult.com"
+      "riotHandle": "@ihubanov:matrix.infosec-consult.com",
+      "kyc": false
     },
     {
+      "slotId": 396,
       "name": "MOON LAMBOS KSM DIABLO",
       "stash": "FmxYyX53X8uyjSHXf6Lz21dd3LfUm43Fia1yN2hXayefmqj",
-      "riotHandle": "@moonlambos:matrix.org"
+      "riotHandle": "@moonlambos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 397,
       "name": "Elenode/2",
       "stash": "DXuN5rty7aNtc3rb7s1HQFsNuiXYtQvFv5HtfkWGq5yyhP9",
-      "riotHandle": "@elentronix:matrix.org"
+      "riotHandle": "@elentronix:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 398,
       "name": "avlusnet-k1",
       "stash": "DKPMevVtq1kGNgssnSQrJ8wXtSbba31a99fc2usyc6E6Gu9",
-      "riotHandle": "@lusnet:matrix.org"
+      "riotHandle": "@lusnet:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 399,
       "name": "DeCommas",
       "stash": "D6NDcYP2JceySwC3rcS28fmA728a7Njnoud7tr1JSBEKj5Y",
-      "riotHandle": "@iosif1977:matrix.org"
+      "riotHandle": "@iosif1977:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 400,
       "name": "🛸 Zooper Corp 🛸 NL",
       "stash": "GeSU3Yv52v5Bux66tUYRemisbSmWQ8ykPoUt4N7rBy88LxM",
-      "riotHandle": "@johnuopini:matrix.org"
+      "riotHandle": "@johnuopini:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 401,
       "name": "MC-Kusama2",
       "stash": "EtN5SSSbQK5dPq1P2Baqp1sdFjFCFFjrhKpQ53Ap8gLLPCi",
-      "riotHandle": "@mc_:matrix.org"
+      "riotHandle": "@mc_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 402,
       "name": "EK-Kusama2",
       "stash": "FcRowS859tNnJnWW5WLLqTrsubwuSXBzECYjLbcyQVwJWYv",
-      "riotHandle": "@plasmajack:matrix.org"
+      "riotHandle": "@plasmajack:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 403,
       "name": "Lightning Blocks Thunder",
       "stash": "FWrLZd5xpb3hxjqUTdXcpRoww6w6pBkkbVYxdxkSNycuvXJ",
-      "riotHandle": "@lightningblocks:matrix.org"
+      "riotHandle": "@lightningblocks:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 404,
       "name": "Texas Blockchain Node 1",
       "stash": "EUrmJmk6XzifgYgEAvoDE3YYnHKQYpsFg1ZoTbx3wAdtF3o",
-      "riotHandle": "@srivish:matrix.org"
+      "riotHandle": "@srivish:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 405,
       "name": "ForklessNation ॐ 0",
       "stash": "H2hR9442doETZ5eRFaP2JHKZJKyLUzSH4xbJ56FC17tPuEC",
-      "riotHandle": ["@synapticon:matrix.org", "@Darkstar/forklessnation:matrix.org"]
+      "riotHandle": [
+        "@synapticon:matrix.org",
+        "@Darkstar/forklessnation:matrix.org"
+      ],
+      "kyc": false
     },
     {
+      "slotId": 406,
       "name": "VLADIMIR2",
       "stash": "FFvhijZofjqZEXwE2hvpKHbyNDexDHq3Qk1ti7SaCmYTRF5",
-      "riotHandle": "@gratevladimir:matrix.org"
+      "riotHandle": "@gratevladimir:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 407,
       "name": "capnodes2-sv-validator-0",
       "stash": "HQsZbKE5CatSBgQB1LHws8eZJs3qjV2VB5cxkUyZHagG9oW",
-      "riotHandle": "@hval:matrix.org"
+      "riotHandle": "@hval:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 408,
       "name": "Phoenix/2",
       "stash": "EmAFBdRFbJiyThqSt9vv2vVECcdTU9nJqa3wTxgKCVKMoC4",
-      "riotHandle": "@pho45:matrix.org"
+      "riotHandle": "@pho45:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 409,
       "name": "Vixello",
       "stash": "EiiSBrZ9kPJhPwf114LF6DyrHCLSKucFTS2TPpSH7zWkTTG",
-      "riotHandle": "@vixello:matrix.org"
+      "riotHandle": "@vixello:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 410,
       "name": "avlusnet-k2",
       "stash": "CuJDBSbr22SrXWxK2tfGeWF2zekYJGxAMXbE6KjviJQ6fjn",
-      "riotHandle": "@lusnet:matrix.org"
+      "riotHandle": "@lusnet:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 411,
       "name": "Brightlystake",
       "stash": "DPyccDy3aecJqo2DTpFUFpnQAeaSEj9hbrpEzUSJnScAXpR",
-      "riotHandle": "@brightlystake:matrix.org"
+      "riotHandle": "@brightlystake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 412,
       "name": "DARK-KUSAMA2",
       "stash": "FLMHZJ2arv1K6Cz9E7j5PJcxLvR2AmD5QsRk6kG4XdFxsz5",
-      "riotHandle": "@darkless2001:matrix.org"
+      "riotHandle": "@darkless2001:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 413,
       "name": "Stellarjet Validator",
       "stash": "GkR4gRvFXCTErUAFoQQUF5VWPF13HopwywxdWXCoxwrpSZk",
-      "riotHandle": "@stellarjet:matrix.org"
+      "riotHandle": "@stellarjet:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 414,
       "name": "BRUMMIE",
       "stash": "JHUdcxgy5dhLFu8wXmskpSLnrXH1ue9rYG7oQFUDPqxzX3u",
-      "riotHandle": "@jimmi.1998:matrix.org"
+      "riotHandle": "@jimmi.1998:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 415,
       "name": "Agave",
       "stash": "FGASn5MVrRKpvYkULb9UsMoqjJQFG2p3izNSzCGSzYa2dAP",
-      "riotHandle": "@agave_node:matrix.org"
+      "riotHandle": "@agave_node:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 416,
       "name": "Node_Amused",
       "stash": "HFdL9ybuAzsAH6BzsTNgeCBZ4Vs6s1fzDjGqLovpYBhrf1h",
-      "riotHandle": "@nodeamused:matrix.org"
+      "riotHandle": "@nodeamused:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 417,
       "name": "G-DOT | SUPER WOW 💥",
       "stash": "HHvov74Rs8S9zGJifq7HKw4Ua14medsxokDyyCwjSSDfSj7",
-      "riotHandle": "@g-dot.tech:matrix.org"
+      "riotHandle": "@g-dot.tech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 418,
       "name": "TUZ",
       "stash": "HnM2g4tJ4874HPkLgChhxnZj2ZZfemzR5TT5wGJ538hj7uU",
-      "riotHandle": "@tuz.peter:matrix.org"
+      "riotHandle": "@tuz.peter:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 419,
       "name": "ALEX Validator",
       "stash": "DFfMD5pu594ynygVKHR2NHr4wxUxXyZrZCCHxeD9fbFeRgy",
-      "riotHandle": "@bablorubitel:matrix.org"
+      "riotHandle": "@bablorubitel:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 420,
       "name": "CRYPTO-BUILDER2",
       "stash": "J4ZjgvzLC9XGmsBoHZFTRCBqNCxTp7BcYxxqKmrAhutK4kb",
-      "riotHandle": "@antonio.crypto:matrix.org"
+      "riotHandle": "@antonio.crypto:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 421,
       "name": "GALAXYNODE2",
       "stash": "DwWqJJaEZCnLkaH8sPPYDhTS1nE7jvHiD1VEVGS3Hg54UDF",
-      "riotHandle": "@galaxymen:matrix.org"
+      "riotHandle": "@galaxymen:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 422,
       "name": "maths-valids-5",
       "stash": "EYvNriDFcDw7KXVjEDsQEpky4RXxXcrYGrS9Dg9Q866yDSs",
-      "riotHandle": "@mathcrypto:matrix.org"
+      "riotHandle": "@mathcrypto:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 423,
       "name": "Maidan_Validator",
       "stash": "DtUd41rpZzvgd5YBfJWRwpr56ZSQEKTvig12gNEhpKq6iAg",
-      "riotHandle": "@maidan.ev:matrix.org"
+      "riotHandle": "@maidan.ev:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 424,
       "name": "DOZENODES3",
       "stash": "HnGgDUuyT97UcSpHhPaxY1h2MPFAjE1qiS9oKRMx5md6464",
-      "riotHandle": "@dozen:matrix.org"
+      "riotHandle": "@dozen:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 425,
       "name": "SONYA-STAKING",
       "stash": "HnEhWv595YMcYPFrTZAQBC4Q8wnoj3nLAfTHpbk6nbBurFY",
-      "riotHandle": "@perechenkos:matrix.org"
+      "riotHandle": "@perechenkos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 426,
       "name": "Titan Nodes",
       "stash": "DDL4xHwuxi6HFa5wtiikEGQ7yZxTCju3bUXazTxku1Vydrr",
-      "riotHandle": "@titannodes:matrix.org"
+      "riotHandle": "@titannodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 427,
       "name": "METASPAN (also try POOL #50)",
       "stash": "HyLisujX7Cr6D7xzb6qadFdedLt8hmArB6ZVGJ6xsCUHqmx",
-      "riotHandle": "@metaspan:matrix.org"
+      "riotHandle": "@metaspan:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 428,
       "name": "EarnX1",
       "stash": "HFTeZuZ62eRLGgjXgpDKQE7H3GDNE8zVfofJ1sr2DEsKLpL",
-      "riotHandle": "@earnxstake:matrix.org"
+      "riotHandle": "@earnxstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 429,
       "name": "HFR 01 bis - ✨✨💎💎💎✨✨ - 🇫🇷",
       "stash": "DVGEcpXkRRhkzXLpWFLZjDYu98MLZ27qj9zLr19XdaGupzX",
-      "riotHandle": "@amallyn:matrix.org"
+      "riotHandle": "@amallyn:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 430,
       "name": "Infinity/2",
       "stash": "ESM8k6WhtMu8gotAkmuNrGhrG9RR7mAfvLARyif9Gqjvu2P",
-      "riotHandle": "@zeb09:matrix.org"
+      "riotHandle": "@zeb09:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 431,
       "name": "Antrome/2",
       "stash": "HyeiEyrdKTvJBpgSXNFtsYGLZiaWjSLjTSTDwZT7WDNwzi2",
-      "riotHandle": "@antrome:matrix.org"
+      "riotHandle": "@antrome:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 432,
       "name": "EarnX2",
       "stash": "FJeLXJd6BSkhye8fY6GzVXmog6NLZfb7u3M6ZnJaHAr4eJc",
-      "riotHandle": "@earnxstake:matrix.org"
+      "riotHandle": "@earnxstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 433,
       "name": "Maidan_Validator-2",
       "stash": "E2YYXgWRksADrZqKB7UNtUEo1L8aMwdvQ2byXbz6vWYmhHj",
-      "riotHandle": "@maidan.ev:matrix.org"
+      "riotHandle": "@maidan.ev:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 434,
       "name": "STRAWBERRY-STAKING2",
       "stash": "DXo9ZVunhLbLoXFGipMimLP9T5JXWiFh7KdERqvene8nsqs",
-      "riotHandle": "@sweetberry:matrix.org"
+      "riotHandle": "@sweetberry:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 435,
       "name": "TUZ2",
       "stash": "FRyidReK7r5Uq49nbQnGvngMWuLWngzSf9SCbqgAMYQWXNe",
-      "riotHandle": "@tuz.peter:matrix.org"
+      "riotHandle": "@tuz.peter:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 436,
       "name": "BRUMMIE2",
       "stash": "G4cQFMqRpWSzkNKxM2Uk6AVEShK2vCSWg7BWM34WZLw8dYn",
-      "riotHandle": "@jimmi.1998:matrix.org"
+      "riotHandle": "@jimmi.1998:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 437,
       "name": "Stellarjet-Validator-2",
       "stash": "GZoYdZryb1MZG7d5LS2hsnazRS6CLxPgJUY15CSMGka6UnL",
-      "riotHandle": "@stellarjet:matrix.org"
+      "riotHandle": "@stellarjet:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 438,
       "name": "Texas Blockchain Node 2",
       "stash": "CwUhDjLKnvtjLM5Caxh4KFEeH5B4LezYM297TxnS7xQw7aB",
-      "riotHandle":  ["@aharris:austin-harris.com", "@srivish:matrix.org"]
+      "riotHandle": ["@aharris:austin-harris.com", "@srivish:matrix.org"],
+      "kyc": false
     },
     {
+      "slotId": 439,
       "name": "SONYA-STAKING2",
       "stash": "EfkeewT5dhAtX7guAuiQ3zHcMAAZm2NvG5iqEdApyCd4Xpm",
-      "riotHandle": "@perechenkos:matrix.org"
+      "riotHandle": "@perechenkos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 440,
       "name": "lucasyoda02",
       "stash": "GybNVXEADoifhWqYBzpPpKDvRYyhjtQHSVWm8rtdkaR889f",
-      "riotHandle": "@lucasyoda:matrix.org"
+      "riotHandle": "@lucasyoda:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 441,
       "name": "BlockAndWhite",
       "stash": "CwPFXLx7NmPRsQyAFTBscxK7Ph1sJ9Ngekc6rXMxTwdw5PZ",
-      "riotHandle": "@cristi_an_m:matrix.org"
+      "riotHandle": "@cristi_an_m:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 442,
       "name": "BestValidator-kusama1",
       "stash": "FJgeBDUj4gF2rYxLmxc7QcccEMZQ26xudp4sro3HFMGZMRL",
-      "riotHandle": "@mosonyi:matrix.org"
+      "riotHandle": "@mosonyi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 443,
       "name": "KEBAB-STAKING",
       "stash": "FSWjWARYDKkqV5ggQ8gbtkXPX2qMX7tkLsgjyDS48JD44pz",
-      "riotHandle": "@fatih.oskan:matrix.org"
+      "riotHandle": "@fatih.oskan:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 444,
       "name": "SPARTA",
       "stash": "HU9ZyZqTJopohQWXsnFY8NZBNjNw17KYnzoxnHn8RtCz8ko",
-      "riotHandle": "@sparta-club:matrix.org"
+      "riotHandle": "@sparta-club:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 445,
       "name": "Aperture Mining 🎂 0",
       "stash": "FJcnsNkMjY8tgJrDVeq5CKoB1b4Au2xGQjaMv8Ax5QAiV6p",
-      "riotHandle": "@aperture-exe:matrix.org"
+      "riotHandle": "@aperture-exe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 446,
       "name": "Mermaid",
       "stash": "Drb5XkyGvm26ph6d1DE4wxbwqiUCKyVXpcThBUSHE4VxrB7",
-      "riotHandle": "@mermaidonline:matrix.org"
+      "riotHandle": "@mermaidonline:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 447,
       "name": "maths-valids-1",
       "stash": "Dek7ze8nGoTWpuperdvx6nmyZtb41CQN97ypX9enfT9jM5S",
-      "riotHandle": "@mathcrypto:matrix.org"
+      "riotHandle": "@mathcrypto:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 448,
       "name": "FILIGRAN-STAKING",
       "stash": "Em8eSvrG2gmTJbzmYcsuGiGbgrdUk61duLCd5LK5fMDoRzY",
-      "riotHandle": "@tomas.staking:matrix.org"
+      "riotHandle": "@tomas.staking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 449,
       "name": "FINSTAKING",
       "stash": "FwJ29P5h8b72EM2pmHLUTuF6pCpwVqmAzuA19v3z7uSazfP",
-      "riotHandle": "@hannskorhonen:matrix.org"
+      "riotHandle": "@hannskorhonen:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 450,
       "name": "STAKEWORLD/01",
       "stash": "CtEni6wrP7Kz2KWus9Y6vQWuhLqJpd9mQFTmTvw8T7FLui8",
-      "riotHandle": "@stakeworld:matrix.org"
+      "riotHandle": "@stakeworld:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 451,
       "name": "TRUSTSTAKE",
       "stash": "D5xebnhvC1DNuJ4LckoYWj8kvaKuqZ7UzNucogn89p6wRJv",
-      "riotHandle": "@fernando.rosso:matrix.org"
+      "riotHandle": "@fernando.rosso:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 452,
       "name": "DomiNodes-Alpha",
       "stash": "EQMipshNYYvHL427XS2HyTvisAhTokXKZfhaRkKxz6sKxQd",
-      "riotHandle": "@dominodes:matrix.org"
+      "riotHandle": "@dominodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 453,
       "name": "SILICON",
       "stash": "Ht23NqcfSdMRAAmKs9Xa7woDCSiiaXtYvjwZ78aBBksMtAE",
-      "riotHandle": "@konti.konti:matrix.org"
+      "riotHandle": "@konti.konti:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 454,
       "name": "Aperture Mining 🎂 1",
       "stash": "Hcbo6hyfVgExCKrjmJic9bg4gLWgYy6HLrjcXUYy2VgLG7a",
-      "riotHandle": "@aperture-exe:matrix.org"
+      "riotHandle": "@aperture-exe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 455,
       "name": "Titan Nodes Cronus",
       "stash": "HNkmp2AGZoX57CdDQLWQTXa8FTKcuQu7CFq2rmLuU2ryPop",
-      "riotHandle": "@titannodes:matrix.org"
+      "riotHandle": "@titannodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 456,
       "name": "snf-ksm-➌-validator",
       "stash": "Ht6FbjRKCZ4HW2dNd9w2AtYsed2cHDQTPWXdE2Qm1FQMU4e",
-      "riotHandle": "@ihubanov:matrix.infosec-consult.com"
+      "riotHandle": "@ihubanov:matrix.infosec-consult.com",
+      "kyc": false
     },
     {
+      "slotId": 457,
       "name": "9Stake",
       "stash": "CyzTh1chfwDa5GuBDfE3BC7e1H7Jnvoz21gf79ckeMJ7xeg",
-      "riotHandle": "@kusama.9stake.9gag:matrix.org"
+      "riotHandle": "@kusama.9stake.9gag:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 458,
       "name": "Watermelon",
       "stash": "FPc6HXzVyCbsarcyLEN6UnHbhWxdUputwEe5saQxmMUj63X",
-      "riotHandle": "@watermelonnode:matrix.org"
+      "riotHandle": "@watermelonnode:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 459,
       "name": "SIGNY9",
       "stash": "E53UnBMiLVW2EABseyk3oAtXTJcq7zkrU8RbjEVRUTGLH9f",
-      "riotHandle": "@signy9:matrix.org"
+      "riotHandle": "@signy9:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 460,
       "name": "BlockCtrl",
       "stash": "FALhH3XMMbXiKoG6u9XS8CJuxiA2eKA2HFn4oh3JpfwvBNF",
-      "riotHandle": "@alberto_bc:matrix.org"
+      "riotHandle": "@alberto_bc:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 461,
       "name": "SPARTA2",
       "stash": "FCUvpYbs2H7Dch98wenjHxDYkjn4DiSV3MQuryARPjpWfHd",
-      "riotHandle": "@sparta-club:matrix.org"
+      "riotHandle": "@sparta-club:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 462,
       "name": "web3:stakenode",
       "stash": "FvdwMNP57nRWEsNZZsrHWKqnbmduy4jBAC8MeLmgi9Yp8sA",
-      "riotHandle": "@stakenode:matrix.org"
+      "riotHandle": "@stakenode:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 463,
       "name": "ALESSIO-2",
       "stash": "FqKWQbLrARHhcvW8gXjmJXc2EC5Ah3xMKhuXxDJJPDChhdZ",
-      "riotHandle": "@ironoa:matrix.org"
+      "riotHandle": "@ironoa:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 464,
       "name": "pathrocknetwork",
       "stash": "Hk7snkgFNhrDRfwveEdpwgwu6D9uUmXwcLy3dZgM2EhHVJq",
-      "riotHandle": "@pathrock:matrix.org"
+      "riotHandle": "@pathrock:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 465,
       "name": "Green Cloud",
       "stash": "DPb2z99bbieLXWADo1dsLTijTc84vktx5nZmu79NztbC3NS",
-      "riotHandle": "@green-cloud:matrix.org"
+      "riotHandle": "@green-cloud:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 466,
       "name": "infsysgroup",
       "stash": "J6ixMhTj9UmgZtNiWVGs1SdGm9HXSj7z2Emjc9syMgGdN5X",
-      "riotHandle": "@ignatev:matrix.org"
+      "riotHandle": "@ignatev:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 467,
       "name": "stakeplus-bm1-4-1",
       "stash": "F8FswEGD1quEyNciuR9KwsragUmqnk7mFLqmAdRdnY9Sdwx",
-      "riotHandle": "@stakeplus:matrix.org"
+      "riotHandle": "@stakeplus:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 468,
       "name": "stakeplus-bm1-4-2",
       "stash": "DqsZ7nrch8Ro9HqP1ZX7CbbpZFWy2V4bWjWWjNA2PAehZsW",
-      "riotHandle": "@stakeplus:matrix.org"
+      "riotHandle": "@stakeplus:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 469,
       "name": "Abrarad",
       "stash": "EmDCmQ3wc2yW6gpAsBFXV22EgPpeAd8KoksFyCn5RkqqcfV",
-      "riotHandle": "@abraradi:matrix.org"
+      "riotHandle": "@abraradi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 470,
       "name": "BestValidator-kusama2",
       "stash": "F5RTgwqTgKHPTcVk1eiAwXYtx3BWo9r6iAmhsjH9RRn62jb",
-      "riotHandle": "@mosonyi:matrix.org"
+      "riotHandle": "@mosonyi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 471,
       "name": "STAKEWORLD/02",
       "stash": "FNPCfXrsrA8775HGuRvK9seULKpcnxNTTKTGUL4h267YHvw",
-      "riotHandle": "@stakeworld:matrix.org"
+      "riotHandle": "@stakeworld:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 472,
       "name": "Mermaid Magic",
       "stash": "J4mt2MknXc8AsLHt5M6pzFD1odT9sZrufEHyCPjbm8FafJd",
-      "riotHandle": "@mermaidonline:matrix.org"
+      "riotHandle": "@mermaidonline:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 473,
       "name": "Steak ♨ Noodles / 3",
       "stash": "DbK3xXFoiFXqnnqzqDrywg2UzkQcAS3xpCCfSTtEGnb27tQ",
-      "riotHandle": "@steak_and_noodles:matrix.org"
+      "riotHandle": "@steak_and_noodles:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 474,
       "name": "Watermelon WM2",
       "stash": "EUWaPzJV9soamnUPSUcp76mEjQkLZj4nt659DvdVzRG9k6a",
-      "riotHandle": "@watermelonnode:matrix.org"
+      "riotHandle": "@watermelonnode:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 475,
       "name": "DOZENODES",
       "stash": "DDhVgn62SE2riWjS6U4AaYtfLNKuFxqTU32EnqAtAuxqM58",
-      "riotHandle": "@dozen:matrix.org"
+      "riotHandle": "@dozen:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 476,
       "name": "yevhen Validator",
       "stash": "GaBaRT2R67TW8QxZtN7S4EUXMh5viYY2q6xiLoDcxodfzmq",
-      "riotHandle": "@yevhenbasarab:matrix.org"
+      "riotHandle": "@yevhenbasarab:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 477,
       "name": "summerstake",
       "stash": "Gh86VtoTd3c5fGvCjSRhymndg8AUpR4NZAit8XVGCv985Wf",
-      "riotHandle": "@summerstak3:matrix.org"
+      "riotHandle": "@summerstak3:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 478,
       "name": "Green Cloud In the sky",
       "stash": "HLfUw3p1W5mx57wJeDG6n6uRYDR7H22ViRLuCTgbJCirbai",
-      "riotHandle": "@green-cloud:matrix.org"
+      "riotHandle": "@green-cloud:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 479,
       "name": "Exotic Stake-1",
       "stash": "EtuNrxRfSrBve23jguVAmz3YVCFKCJqFdaHMAW8HTUxkCaP",
-      "riotHandle": "@exoticstake:matrix.org"
+      "riotHandle": "@exoticstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 480,
       "name": "web3:stakenode_01",
       "stash": "D3Sr3PozgPypkBzKBheGSJbqu8m4idenBPaWtZUXLWPtjJT",
-      "riotHandle": "@stakenode:matrix.org"
+      "riotHandle": "@stakenode:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 481,
       "name": "Chris Staking/k1",
       "stash": "FDSK4DywqKzDweKQe7QyWEtAasMLWnxLzQWY2EY8YNW6G32",
-      "riotHandle": "@clang:matrix.org"
+      "riotHandle": "@clang:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 482,
       "name": "Chris Staking/k2",
       "stash": "EAqxvPZ3nxyfum6d8DFBeGuykQayJHtE6DyCcHMyd6o57WZ",
-      "riotHandle": "@clang:matrix.org"
+      "riotHandle": "@clang:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 483,
       "name": "Vel_Validator",
       "stash": "EaQghcv5V7uFSvj1yHgXxnhTy7y7KP7Lfgms1rvQqbwXBZN",
-      "riotHandle": "@vda0390:matrix.org"
+      "riotHandle": "@vda0390:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 484,
       "name": "KYB-validator-1",
       "stash": "ELyU4uhMAfes3SQBZdSdBK6PtKyyTJMvEQayMUcFqZFPVFR",
-      "riotHandle": "@kostyayesikov:matrix.org"
+      "riotHandle": "@kostyayesikov:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 485,
       "name": "Steak ♨ Noodles / 4",
       "stash": "EDbQj2GD1iAJ8pU32FSAadWaXQvxYjUs6D4gG2jRaMeQ9hG",
-      "riotHandle": "@steak_and_noodles:matrix.org"
+      "riotHandle": "@steak_and_noodles:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 486,
       "name": "antistake-kusama-0",
       "stash": "DwQx7moAfebiPXDq1kc3oTvByyBWhjFoyXY6fu5xvucTEB6",
-      "riotHandle": "@lucasvm:matrix.org"
+      "riotHandle": "@lucasvm:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 487,
       "name": "gislemon-ksm01",
       "stash": "F5hGnoJXcYcd1nHShm731aPK9Cw4eJbSChLgSFs2cuFJtQa",
-      "riotHandle": "@gislemon:matrix.org"
+      "riotHandle": "@gislemon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 488,
       "name": "gislemon-ksm02",
       "stash": "GUw3gm93T85i9Syb4hA3NotNMFgCB56p7osxi3hnoqforMj",
-      "riotHandle": "@gislemon:matrix.org"
+      "riotHandle": "@gislemon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 489,
       "name": "bazar-staking",
       "stash": "EmQzoy26WkMMqQtA3535eJEKZUhQ54zgeHssopaX565pFki",
-      "riotHandle": "@bazar-staking:matrix.org"
+      "riotHandle": "@bazar-staking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 490,
       "name": "🦜dotsamastake_ksm1🦜",
       "stash": "FgqABNZt4EuW4Xx6y3YRxdY2eJ7P6Mq1z7ukeqxQLheFVvC",
-      "riotHandle": "@dotsamastake.io:matrix.org"
+      "riotHandle": "@dotsamastake.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 491,
       "name": "🦜dotsamastake_ksm2🦜",
       "stash": "EaNqkv87hVL8vvwBcTxeCkECkzRuyFLVtSmrVCDhfj4dNmf",
-      "riotHandle": "@dotsamastake.io:matrix.org"
+      "riotHandle": "@dotsamastake.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 492,
       "name": "Alzymologist-03",
       "stash": "EAp3SeY72kfoCUV9SRbmZyiWVEhoQevwLASo7HmiTxCVKuv",
-      "riotHandle": "@alexander_slesarev:matrix.zymologia.fi"
+      "riotHandle": "@alexander_slesarev:matrix.zymologia.fi",
+      "kyc": false
     },
     {
+      "slotId": 493,
       "name": "Alzymologist-02",
       "stash": "HPb2Eumk74WJ1rCnVL8rdQvJ8ALyUhxRmGxVrbHbuQ8fFMW",
-      "riotHandle": "@alexander_slesarev:matrix.zymologia.fi"
+      "riotHandle": "@alexander_slesarev:matrix.zymologia.fi",
+      "kyc": false
     },
     {
+      "slotId": 494,
       "name": "JelliedOwl_1",
       "stash": "FfKiC6eiRapSgPnZd953vAbMAsR5J9c7x37rPuHMSKpruqD",
-      "riotHandle": "@jelliedowl:matrix.org"
+      "riotHandle": "@jelliedowl:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 495,
       "name": "openbitlab2",
       "stash": "DYGkobGPb7Hc6c7dZbxTDX3DnGEAjXcv1kuNV3tQvkscxUL",
-      "riotHandle": "@openbitlab_:matrix.org"
+      "riotHandle": "@openbitlab_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 496,
       "name": "big-wave-ksm-01",
       "stash": "CrTPV874i4VNTjkCfQbGpPT338dhyu27w6poWrKuZZpEz17",
-      "riotHandle": "@big-wave:matrix.org"
+      "riotHandle": "@big-wave:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 497,
       "name": "Alzymologist-00",
       "stash": "EQHdPbmAySkGg8UmTDfnVTkU7FhQ1ytKPMopsoN7Kuy2eth",
-      "riotHandle": "@agryaznov:matrix.parity.io"
+      "riotHandle": "@agryaznov:matrix.parity.io",
+      "kyc": false
     },
     {
+      "slotId": 498,
       "name": "blockbus",
       "stash": "GXihX81hjYw4f5VQd9s1zsLU1poyo6hGqfPtcx2GJDVyyYx",
-      "riotHandle": "@ccole1:matrix.org"
+      "riotHandle": "@ccole1:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 499,
       "name": "LongNode",
       "stash": "DizXV8fnNYr1HqBm9M3h4fUa8EdCTZWRyYpXF18s9JmWxh1",
-      "riotHandle": "@rdovgan:matrix.org"
+      "riotHandle": "@rdovgan:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 500,
       "name": "BlockCtrl-2",
       "stash": "Cx8jJMMwTcEwTMHSQDdwTwFJCmmTsMVz25auV95WkFBZnZv",
-      "riotHandle": "@alberto_bc:matrix.org"
+      "riotHandle": "@alberto_bc:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 501,
       "name": "Vel_Validator_02",
       "stash": "HnidBVNsn5MdboWwHRRoVHuzzFEZZFgenQb3KmgEoRt3tTJ",
-      "riotHandle": "@vda0390:matrix.org"
+      "riotHandle": "@vda0390:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 502,
       "name": "bigTuna",
       "stash": "FntXNA6GesCTLJQZUt1LjyUCxkTbhCYny4Y6UdT8et1aqNt",
-      "riotHandle": "@tunabig:matrix.org"
+      "riotHandle": "@tunabig:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 503,
       "name": "KYB-validator-2",
       "stash": "CmS4wQk2P9DboQ3SVAJct1j948QbNhbJJmSrqvFMUSLATNZ",
-      "riotHandle": "@kostyayesikov:matrix.org"
+      "riotHandle": "@kostyayesikov:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 504,
       "name": "Swiss Bond/2",
       "stash": "E2gCFEisQ3k4LmaJHBysj8f1SRoG6jCo5ffFdX9XidqsjDC",
-      "riotHandle": "@matteo_swissbond:matrix.org"
+      "riotHandle": "@matteo_swissbond:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 505,
       "name": "Darkstar Ω Muladhara",
       "stash": "HKskSdW3uDspu9x8Q9ph8tiKvbLE7Rd2n5cCKaG5rHL7DUv",
-      "riotHandle": "@darkstar/forklessnation:matrix.org"
+      "riotHandle": "@darkstar/forklessnation:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 506,
       "name": "METASPAN3 (also try POOL #50)",
       "stash": "JKhBBSWkr8BJKh5eFBtRux4hsDq4sAxvvmMU426qUA9aqEQ",
-      "riotHandle": "@metaspan:matrix.org"
+      "riotHandle": "@metaspan:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 507,
       "name": "anvel",
       "stash": "EPbpqewHLsudtHdJnyMSR3SqP3fwUSSGssP18qsW1UABaFr",
-      "riotHandle": "@anvel:matrix.org"
+      "riotHandle": "@anvel:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 508,
       "name": "Rekt Street Capital",
       "stash": "FkrektytDeepNHKZMMiPYZsrmgrVum9cqZmE4fsz4cotKs9",
-      "riotHandle": "@rektstreet:matrix.org"
+      "riotHandle": "@rektstreet:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 509,
       "name": "djandre2",
       "stash": "Fynn5CRPtc8xH1gM5emZoRkXEZstrJE3ixmtNqTKa9yaV56",
-      "riotHandle": "@djandre77:matrix.org"
+      "riotHandle": "@djandre77:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 510,
       "name": "maxaon_Validator",
       "stash": "EGU1mTpaHKdwqXJwZGSmyEhuh1Exy2o4yd6UyJ9HcGfBsjN",
-      "riotHandle": "@sasha1983:matrix.org"
+      "riotHandle": "@sasha1983:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 511,
       "name": "kuzo",
       "stash": "EAcDiMkyNsmiRY539ELBzSmjVwpfrcmPXEJLRME6DTiN4GF",
-      "riotHandle": "@guzo:matrix.org"
+      "riotHandle": "@guzo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 512,
       "name": "ERN VENTURES",
       "stash": "FHsDBsDmxzsANzvDrPBCzxyRAAYuTHCoe5d6vzi2qEdTBKk",
-      "riotHandle": "@ernventures:matrix.org"
+      "riotHandle": "@ernventures:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 513,
       "name": "Powerstake-k1",
       "stash": "HnZafcsErZXmc6gUupBDzNVayTQbraN5fvzoC7XYKev8f5q",
-      "riotHandle": "@powerstake:matrix.org"
+      "riotHandle": "@powerstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 514,
       "name": "Kobredabre/2",
       "stash": "EDeGMwoAZ3SQwcGSb5oLPxSqNCYLCMHrfw4gJ9CM8Gr9XiA",
-      "riotHandle": "@kobredabre:matrix.org"
+      "riotHandle": "@kobredabre:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 515,
       "name": "DomiNodes-Bravo",
       "stash": "DN2oxCHnJviLK1NoYdzSNo9n9gmH3eBTfLGXSUcoFcq5khX",
-      "riotHandle": "@dominodes:matrix.org"
+      "riotHandle": "@dominodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 516,
       "name": "STAKEMORE",
       "stash": "Gvtpyq5SFo7bcjA287yCqN7UqrpdBS7vYcMbyzaTKBDmUmc",
-      "riotHandle": "@stakemore:matrix.org"
+      "riotHandle": "@stakemore:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 517,
       "name": "Leostake",
       "stash": "HNGMhUpVnZjuJ3kQcBAMF4KVywdkk2SCxQ4TAt6QBKtMCFh",
-      "riotHandle": "@leostake:matrix.org"
+      "riotHandle": "@leostake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 518,
       "name": "GROUP_THERAPY",
       "stash": "GcS4cm9Zuk1EYAm3N92TXgUGAhG18Y4g9niZ4Pz1Ak9fu3C",
-      "riotHandle": "@agt_staking:matrix.org"
+      "riotHandle": "@agt_staking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 519,
       "name": "MisfitsStaking-1",
       "stash": "ELsGbjUZ8ENbBDKniysdA5CxmCAkwWQKW5pQtkQDx1x6wej",
-      "riotHandle": "@rcfromcle:matrix.org"
+      "riotHandle": "@rcfromcle:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 520,
       "name": "😻 Stake Kat 😻",
       "stash": "GefTiMd4roQrRkJzurdLdGsoAUkmMkiGoYd6Cvu5oqCgamX",
-      "riotHandle": "@fmonza:matrix.org"
+      "riotHandle": "@fmonza:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 521,
       "name": "Powerstake-k2",
       "stash": "J6ikoEFkP3Fp5wTK3vCdmVWaZv2UPcBiN3KneB9RFqZbvHS",
-      "riotHandle": "@powerstake:matrix.org"
+      "riotHandle": "@powerstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 522,
       "name": "LEGEND",
       "stash": "GHewg8AxLL7JpRYDoqEyTk5bhGndhMvsDWo68St7D9YDH9Z",
-      "riotHandle": "@legend7341216:matrix.org"
+      "riotHandle": "@legend7341216:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 523,
       "name": "goblinsama",
       "stash": "Gsq5DqZSpKf3wB4JSj57fQmPWPzSYUk2WR3T4XDRm2SFPwC",
-      "riotHandle": "@goblinsama:matrix.org"
+      "riotHandle": "@goblinsama:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 524,
       "name": "bisk-spot",
       "stash": "GEuxhtKAzwWZ3vhM4dB3sN2vVJP9UcEAZVfLi8Vq12LYQZn",
-      "riotHandle": "@kusamapp:matrix.org"
+      "riotHandle": "@kusamapp:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 525,
       "name": "CoinStudio CS1",
       "stash": "JBmYvpebasxckBsohyyWse7yggsowfgt5xRJvkzu2txUJdi",
-      "riotHandle": "@coinstudio:matrix.org"
+      "riotHandle": "@coinstudio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 526,
       "name": "Stake Hulk",
       "stash": "J3uneckXiaJvUiBnGf6Dp3bBgP2Bk615vGcyyXNh3NsTNBm",
-      "riotHandle": "@stakehulk:matrix.org"
+      "riotHandle": "@stakehulk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 527,
       "name": "prostakers-com-ksm-01",
       "stash": "JLcdsEGtVtR22RuRPDa2tCMwBCox1FnyhJS8UWwSge1q8L6",
-      "riotHandle": "@prostakers.com:matrix.org"
+      "riotHandle": "@prostakers.com:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 528,
       "name": "Finoa-Consensus-Services",
       "stash": "GjbbMnzeixsPHe1nbsnd6BukJCrBkGADofEJVHPagNSkZUr",
-      "riotHandle": "@lly_finoa_io:matrix.org"
+      "riotHandle": "@lly_finoa_io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 529,
       "name": "Xalamus",
       "stash": "FfbGaF1B6hNMPNKcjgyciU2RqbAgF8UmW1dAxTi667odgR5",
-      "riotHandle": "@xalamus:matrix.org"
+      "riotHandle": "@xalamus:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 530,
       "name": "Exotic Stake-2",
       "stash": "HtNS2YwSFCqZUDJQAiBTKMd2ajuLWRh5KEiiMbsccpgwSUA",
-      "riotHandle": "@exoticstake:matrix.org"
+      "riotHandle": "@exoticstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 531,
       "name": "NRD Labs",
       "stash": "ESCob7AAYWVdifL9jaYEokbZ9rfRrRtGUQ22EK1N77Nc67c",
-      "riotHandle": "@nrdlabs:matrix.org"
+      "riotHandle": "@nrdlabs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 532,
       "name": "Stake Hulk-2",
       "stash": "E7bPDzL95cds5Qb4zmkDY3RBgQ6WiV7m6ZQADnszKvVuyBW",
-      "riotHandle": "@stakehulk:matrix.org"
+      "riotHandle": "@stakehulk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 533,
       "name": "Chain service",
       "stash": "Gv7aohxceo5XqeDZzJzxR5fxGaZwQUzSpmRzNXSLFvJdvbw",
-      "riotHandle": "@chainservice:matrix.org"
+      "riotHandle": "@chainservice:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 534,
       "name": "Alzymologist-01",
       "stash": "EkDQN44Bn4SB9oLQTk5fSxCeRPFYAndH8dCGNeRAMLjfp41",
-      "riotHandle": "@sasha:parity.io"
+      "riotHandle": "@sasha:parity.io",
+      "kyc": false
     },
     {
+      "slotId": 535,
       "name": "kuzo02",
       "stash": "DuJbrYe3J2f7ZKSh86sxTUZcB7GTcRyoAmb2bbuht3QnTnk",
-      "riotHandle": "@guzo:matrix.org"
+      "riotHandle": "@guzo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 536,
       "name": "Vixello-II",
       "stash": "Hv7opiixZpSZQMxfHhxAVv7ye12Fs8WwadwQPcAgKcSBeFF",
-      "riotHandle": "@vixello:matrix.org"
+      "riotHandle": "@vixello:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 537,
       "name": "punkrock-sv-validator-0",
       "stash": "J75Bj4JkQ1oZ5Y2UCtLBq8FFHDdnrfTQgDGErvk9kyS1wMn",
-      "riotHandle": "@punkrock:matrix.org"
+      "riotHandle": "@punkrock:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 538,
       "name": "lesnik_utsa",
       "stash": "D5khA3qGvd8SDXepSrCGmYRWbNUzdJpjEyg6m1mFT7VtHpw",
-      "riotHandle": "@lesnik_utsa:matrix.org"
+      "riotHandle": "@lesnik_utsa:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 539,
       "name": "lesnik_utsa_2",
       "stash": "DwZmVxujvVZmzmLZJ3wNTqyxBYTPDstCxayK6nwSR9HC1tS",
-      "riotHandle": "@lesnik_utsa:matrix.org"
+      "riotHandle": "@lesnik_utsa:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 540,
       "name": "Abrarad/2",
       "stash": "GHvBTjiMP9DN5ktScvE4j5MiXhzeiRXGCaF8dMVX2LH6mGv",
-      "riotHandle": "@abraradi:matrix.org"
+      "riotHandle": "@abraradi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 541,
       "name": "yevhen Validator2",
       "stash": "FoAcuru54tGpm6TE3eHVF3gkKtTmTKjLUxBRXMvi1myi6uH",
-      "riotHandle": "@yevhenbasarab:matrix.org"
+      "riotHandle": "@yevhenbasarab:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 542,
       "name": "prostakers-com-ksm-03",
       "stash": "E3YZhhz3AhFNbVyXYN6jnCucqUy39J3S3uAf4W4zaPzo2zd",
-      "riotHandle": "@prostakers.com:matrix.org"
+      "riotHandle": "@prostakers.com:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 543,
       "name": "bigTuna2",
       "stash": "Fd7eRTG43D5ppwT2ZHoLCPXQQy3VW5M4NCJepXusAXR1bTD",
-      "riotHandle": "@tunabig:matrix.org"
+      "riotHandle": "@tunabig:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 544,
       "name": "SteakChef-k1",
       "stash": "HAGEDeWTMag1By2N27w53C5xfK6mzbNPi9L7RtCamEzThHH",
-      "riotHandle": "@stake-chef:matrix.org"
+      "riotHandle": "@stake-chef:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 545,
       "name": "SteakChef-k2",
       "stash": "Fd4KmS9Bwb1SCfhMLx3bxW1nRGP5M7yUWianwUfHMxdJA5U",
-      "riotHandle": "@stake-chef:matrix.org"
+      "riotHandle": "@stake-chef:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 546,
       "name": "lets_node_2",
       "stash": "Dj369iVi3YEyhpwFELcvYbCr5Jj4ojMLTLCocmYUduozafv",
-      "riotHandle": "@lets_node:matrix.org"
+      "riotHandle": "@lets_node:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 547,
       "name": "Block Bridge",
       "stash": "GqjrCgD6GmZFRSYBr6w1BSuXXbqFgaceDAAezDxKF5XdNQb",
-      "riotHandle": "@blockbridge:matrix.org"
+      "riotHandle": "@blockbridge:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 548,
       "name": "nlz",
       "stash": "GPcV2soyyrNMy5GhE6Dkmdy4DwccrmTQENfGXtJ59y5hWtf",
-      "riotHandle": "@natanlz:matrix.org"
+      "riotHandle": "@natanlz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 549,
       "name": "PROXFARM",
       "stash": "FhnQmArfwMv4B1pHN7HAobrxSNYbP5G6rVHE32DFkiiJcTh",
-      "riotHandle": "@andreesken:matrix.org"
+      "riotHandle": "@andreesken:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 550,
       "name": "blockseeker_io",
       "stash": "HPuireorhWdSCQg5dG1zeGk7XCuAfkb21BtDyLqRuN62k67",
-      "riotHandle": "@blockseeker.io:matrix.org"
+      "riotHandle": "@blockseeker.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 551,
       "name": "Darvin",
       "stash": "HhQifoEAuBYsFrf83pFvHo87voFDMzAY61123HddZ8EScDL",
-      "riotHandle": "@darvin00524:matrix.org"
+      "riotHandle": "@darvin00524:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 552,
       "name": "NOVASAMA_TECHNOLOGIES/VAL_1",
       "stash": "DhK6qU2U5kDWeJKvPRtmnWRs8ETUGZ9S9QmNmQFuzrNoKm4",
-      "riotHandle": "@solocrack_:matrix.org"
+      "riotHandle": "@solocrack_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 553,
       "name": "Cypher Labs Xeon",
       "stash": "HvshspvW9yk29mrCSBLcpv8MRbna4incDkt5C86ezZ6XKPH",
-      "riotHandle": "@fred3ric:matrix.org"
+      "riotHandle": "@fred3ric:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 554,
       "name": "Krawiec",
       "stash": "CzB1XBwkko3Az7DNZDPigZ1bjzLxELAGnLBnFGRdQ4PXTqZ",
-      "riotHandle": "@krawiec.:matrix.org"
+      "riotHandle": "@krawiec.:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 555,
       "name": "MerkleTribe Ξ Kazaki",
       "stash": "HsXaiGQ7cAUctDTnkX535xFamCEnki8XvtnMMMU6LRapePw",
-      "riotHandle": "@merkletribe:matrix.org"
+      "riotHandle": "@merkletribe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 556,
       "name": "ERN VENTURES-1",
       "stash": "Gjv9ZGF9Sz5GEixULU7Dmq7z8zVRmQFj2Y31qfpwbhsvo76",
-      "riotHandle": "@ernventures:matrix.org"
+      "riotHandle": "@ernventures:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 557,
       "name": "enby-collective-achim-1",
       "stash": "GMCdBvMap5gNLshE9cWWJyTCsBFr3Tp7cUHXisUG16C95kg",
-      "riotHandle": "@achim:parity.io"
+      "riotHandle": "@achim:parity.io",
+      "kyc": false
     },
     {
+      "slotId": 558,
       "name": "maxaon_Validator2",
       "stash": "DKSw7Ypw2TUQc1Xfvd3s8L7kZ6gkFtZHMfSSd15LLBbqQRC",
-      "riotHandle": "@sasha1983:matrix.org"
+      "riotHandle": "@sasha1983:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 559,
       "name": "NRD Labs-1",
       "stash": "HcKyUJ3iAjFqgt3ba7X7W8KApW4PFus6dUa6Q53Nu4hUKoy",
-      "riotHandle": "@nrdlabs:matrix.org"
+      "riotHandle": "@nrdlabs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 560,
       "name": "Chain service-1",
       "stash": "HEcu5goarUbhsvDHrFVhSTHWbGHnD778NALbi3v9145ytLL",
-      "riotHandle": "@chainservice:matrix.org"
+      "riotHandle": "@chainservice:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 561,
       "name": "MerkleTribe Ξ Bayaka",
       "stash": "HtLiQjoJrg2hJp4xc75ruiG8EMmpJkkXmRZztomZyQE4qZt",
-      "riotHandle": "@merkletribe:matrix.org"
+      "riotHandle": "@merkletribe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 562,
       "name": "MARKETACROSS-BLOCKBUILDERS",
       "stash": "EzAUyKjTG4BooK598kPGAWJzXqBAzfL77KYYfdqxPzW1G4f",
-      "riotHandle": "@marketacross_bb:matrix.org"
+      "riotHandle": "@marketacross_bb:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 563,
       "name": "Crypto_Pepe",
       "stash": "JFFn5aNhuYnZMuR1hv5PeUprZf6owNupuobL4NH4TEkQYdN",
-      "riotHandle": "@chefireblade:matrix.org"
+      "riotHandle": "@chefireblade:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 564,
       "name": "Magic Tab",
       "stash": "G29SmTWUhXHMQrTBdC8hTMXu5G6YKwt4AsefNqFH8NMi5eq",
-      "riotHandle": "@magictab:matrix.org"
+      "riotHandle": "@magictab:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 565,
       "name": "YAO Gmbh",
       "stash": "HxVdrC3UWVvjSvcH93ntr2J7PRJgM43Duw8nYaGyKwa2VkA",
-      "riotHandle": "@lukayao:matrix.org"
+      "riotHandle": "@lukayao:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 566,
       "name": "Xalamus Squared",
       "stash": "FkPMVMcppToPSdMEohDxhhZYWpYY2ZwfgEaBNog9Vj2f61o",
-      "riotHandle": "@xalamus:matrix.org"
+      "riotHandle": "@xalamus:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 567,
       "name": "lada",
       "stash": "Cn2A8M1tbjYq5BXQWeNs9KKjrkhgbM46UX8BVcUU2qdfV9f",
-      "riotHandle": "@lada-kmv:matrix.org"
+      "riotHandle": "@lada-kmv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 568,
       "name": "enby-collective-achim-2",
       "stash": "HC13ibEcV5GTHW4QfBdYpPSxv5rEdzBpwKZqeXGRntAgvdi",
-      "riotHandle": "@achim:parity.io"
+      "riotHandle": "@achim:parity.io",
+      "kyc": false
     },
     {
+      "slotId": 569,
       "name": "prematurata2",
       "stash": "HCkdHoqeSVE1wH3RTgZypkEDCnWcPXYd65w6gAHa5YJgjwD",
-      "riotHandle": "@prematurata:matrix.org"
+      "riotHandle": "@prematurata:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 570,
       "name": "STAVR",
       "stash": "GWXg67Kn4zo3PTwAf51n4oNdvHzjEAtfZLmbM2a8LairgQV",
-      "riotHandle": "@STAVR:matrix.org"
+      "riotHandle": "@STAVR:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 571,
       "name": "S10_Validator",
       "stash": "EtSjDd392rQQrq4AHuEFk7Mov36cSTypWycm7YAoHaMv42N",
-      "riotHandle": "@velana:matrix.org"
+      "riotHandle": "@velana:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 572,
       "name": "SafeStake_IO_KSM01",
       "stash": "HnqvLipy4zndzJcJWAVJDpDWNMR6ygTVDRym5BeapXHLS2K",
-      "riotHandle": "@safestake:matrix.org"
+      "riotHandle": "@safestake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 573,
       "name": "Brightlystake_01",
       "stash": "D5EsKZAPK3eeyA43U5p8F4WapBS6y5NThot1mUMErkvVasR",
-      "riotHandle": "@brightlystake:matrix.org"
+      "riotHandle": "@brightlystake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 574,
       "name": "landeros",
       "stash": "H6q7Z9t3vuezyoicdKPHTYxVzrCU3JPKJWk3wGyxuEFaB9m",
-      "riotHandle": "@landeros:matrix.org"
+      "riotHandle": "@landeros:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 575,
       "name": "Polkadot_Poland_Validator",
       "stash": "DztKmJLNrXGTZzJnHoD2P6W5ZSD65NeyNCdvmvJqnYkXzf6",
-      "riotHandle": "@polkadot_poland:matrix.org"
+      "riotHandle": "@polkadot_poland:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 576,
       "name": "Polkadot_Poland_Validator_1",
       "stash": "JC3fsv89E4botMv4i6WvhW2AG9DtW2yQoX9Dg9fKkouD8KD",
-      "riotHandle": "@polkadot_poland:martix.org"
+      "riotHandle": "@polkadot_poland:martix.org",
+      "kyc": false
     },
     {
+      "slotId": 577,
       "name": "SUBAETERNA-1-Kusama",
       "stash": "HKoo591knCFvXDgaDFSjYbyyZCHTzqSRurGzYobKEZ8k6D8",
-      "riotHandle": "@subaeterna:matrix.org"
+      "riotHandle": "@subaeterna:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 578,
       "name": "👋 79anvi 🍀",
       "stash": "GHuTRo2jNiXZyc87dU9jRF5iASx1J9G4rgZLPgxxFpj6jD3",
-      "riotHandle": "@79anvi:matrix.org"
+      "riotHandle": "@79anvi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 579,
       "name": "myheartopen",
       "stash": "D3bV95NADtJa8H2xTuq9raaXbniwZWM7b5rqHx4rHffL3o8",
-      "riotHandle": "@alexandalex2007:matrix.org"
+      "riotHandle": "@alexandalex2007:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 580,
       "name": "BRILLIANTINE",
       "stash": "J4KJhPbV5QSFtDmjk13LUtakSBESge4LE3EBZoLBEfkAwaA",
-      "riotHandle": "@brilliantine:matrix.org"
+      "riotHandle": "@brilliantine:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 581,
       "name": "Statutory",
       "stash": "EcxGijR4Er3sfxVHtXnJsG4YjfMEZ6nG3GK5RgxGCnhb3fy",
-      "riotHandle": "@statutoryio:matrix.org"
+      "riotHandle": "@statutoryio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 582,
       "name": "Blockchain Side",
       "stash": "G2Q8mTftjxrrVzkUTuRh1mSemdw7vQSFdxx55gneNc9ptem",
-      "riotHandle": "@sideblockchain:matrix.org"
+      "riotHandle": "@sideblockchain:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 583,
       "name": "Fireblade",
       "stash": "GoBAekE8tyzp52LB1SsduACVSAgoTGY69N2q9evgWcmYpuF",
-      "riotHandle": "@scuolabus:matrix.org"
+      "riotHandle": "@scuolabus:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 584,
       "name": "Biker4b",
       "stash": "HkQzcPWtjHQvrVfDdmDfivc5TB9YQPX2WoyHd65unVCg8H6",
-      "riotHandle": "@biker4b:matrix.org"
+      "riotHandle": "@biker4b:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 585,
       "name": "kokorin9",
       "stash": "EkNcJijf7V2VcPTeS8QJf5CYMrzSXibcPp6WQT9bnfpxLDX",
-      "riotHandle": "@kokorin9:matrix.org"
+      "riotHandle": "@kokorin9:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 586,
       "name": "Cryptography",
       "stash": "DB9bVarUeUkbdACKaBC8zHeSfLQCKdwgJmKCvpcqvC1C6Zw",
-      "riotHandle": "@cryptographyvalidator:matrix.org"
+      "riotHandle": "@cryptographyvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 587,
       "name": "Diamond",
       "stash": "FergEor1g4fw7a81PqXjrQLTWCcXJcFRHJwzVdxrZf9tuQB",
-      "riotHandle": "@diamondvalidator:matrix.org"
+      "riotHandle": "@diamondvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 588,
       "name": "Blockchain Merlin",
       "stash": "DVQzUfux1dT8CD1yrTJRsb2E9dJgy9h1wKknHhSTW44DXob",
-      "riotHandle": "@merlinvvs:matrix.org"
+      "riotHandle": "@merlinvvs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 589,
       "name": "Statute",
       "stash": "EVktWq6LPJNpqVababoL2QKwfpBEh7whCqH8tuGrGWbQE1v",
-      "riotHandle": "@statute:matrix.org"
+      "riotHandle": "@statute:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 590,
       "name": "Finance Ace",
       "stash": "GkPvZbLdoatbBEZRgDBbVUoE32Z4gMtBzFRhgtTru6koxud",
-      "riotHandle": "@acefinance:matrix.org"
+      "riotHandle": "@acefinance:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 591,
       "name": "Smartchoice",
       "stash": "FX8dZmQ842BheqY3bkfUYMVzKoi4FqyeMHY1gz1zHXuHsTU",
-      "riotHandle": "@smartvalidator:matrix.org"
+      "riotHandle": "@smartvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 592,
       "name": "UTFintechLab",
       "stash": "DVFKcqGJsxzujzALCbYfJdzxmMGFgg1bvjtMxPYyGnPd2mU",
-      "riotHandle": "@ufintechlab:matrix.org"
+      "riotHandle": "@ufintechlab:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 593,
       "name": "zlata",
       "stash": "Da29fMrvrhfiEaA1vdk9XCWxcrJGirRmGtdUmxF3Lw26bQq",
-      "riotHandle": "@zlata-kmv:matrix.org"
+      "riotHandle": "@zlata-kmv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 594,
       "name": "skyerdeka",
       "stash": "GJNd3aF2HqTrE22XE5aUWuThkGMPVAcCF1aU1fzBXy7Cwiy",
-      "riotHandle": "@skyerdeka:matrix.org"
+      "riotHandle": "@skyerdeka:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 595,
       "name": "Bueno Validatoro k1",
       "stash": "J9dMF6CESPxdM8RR1HPtdGxX7QbSQRs3dk5sBS4ckuH2o1V",
-      "riotHandle": "@buenovalid:matrix.org"
+      "riotHandle": "@buenovalid:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 596,
       "name": "Bueno Validatoro k2",
       "stash": "FY2bLCFxmFtrN2TDsJ3JfndjYQweukUNmptJ7HNRspfqegS",
-      "riotHandle": "@buenovalid:matrix.org"
+      "riotHandle": "@buenovalid:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 597,
       "name": "blockseeker_io_sentinel",
       "stash": "J6if9c47o81JsMeB75VwkXtx1nVEaMPvQxuMRYhBR8H6ULU",
-      "riotHandle": "@blockseeker.io:matrix.org"
+      "riotHandle": "@blockseeker.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 598,
       "name": "kavkaz",
       "stash": "Ds1PTN8PZ6MY6LhsSv7Df1rX6oG6ao1jcpNRsohY519KQcQ",
-      "riotHandle": "@myxaletishe:matrix.org"
+      "riotHandle": "@myxaletishe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 599,
       "name": "Rhombus",
       "stash": "EDKXrYEqmAnMZnZzzRSby67Fgf5yFUSpbmQMN1rJHPTWbVV",
-      "riotHandle": "@rhombusvalidator:matrix.org"
+      "riotHandle": "@rhombusvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 600,
       "name": "VALIDANDUM-IO | KSM | 01",
       "stash": "DQHKgq1GZwSTkWDzT8aKg6TfKiH2DNPh7w1K5tPo9xTWjN7",
-      "riotHandle": "@validandum.io.lee:matrix.org"
+      "riotHandle": "@validandum.io.lee:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 601,
       "name": "cyberomanov",
       "stash": "HtN9WHEppGjfoCiwbw7kDD7dz6MvbXy13Bd4MnTcADRK9cs",
-      "riotHandle": "@cyberomanov:matrix.org"
+      "riotHandle": "@cyberomanov:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 602,
       "name": "tanusha602",
       "stash": "GynYeFiRHZ2MqvYz96on4Yitia82J1hft2PeXEMr9XLc4LP",
-      "riotHandle": "@tanusha602:matrix.org"
+      "riotHandle": "@tanusha602:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 603,
       "name": "JJB-KSM-Validator2",
       "stash": "E2U3UUbpG4SHCQ5BFJamYrv8yHpCf499dA9G8Cn9uhcvjwb",
-      "riotHandle": "@jjbweb3:matrix.org"
+      "riotHandle": "@jjbweb3:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 604,
       "name": "pointlessnotion",
       "stash": "EXFcC6F2AN93HstWjit6yhUSBHpHMxX94uRQhfsUb4JEcDE",
-      "riotHandle": "@roadswithoutend:matrix.org"
+      "riotHandle": "@roadswithoutend:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 605,
       "name": "nakepelo",
       "stash": "HchNyEKGXDYuNZSCJxZLuDfCnV7J8zaxVCZvUhUM2ueAEST",
-      "riotHandle": "@lagartos:matrix.org"
+      "riotHandle": "@lagartos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 606,
       "name": "Father",
       "stash": "GXNQDB52HeFUpgbcCBMbWsbMmG4ntu9JNXXx34mADjTe4wV",
-      "riotHandle": "@papaksm:matrix.org"
+      "riotHandle": "@papaksm:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 607,
       "name": "LEGEND-2",
       "stash": "Dr9QwogB1x5BH91L4ebVnW2c8ZV9oQDfCRk4RUja5bTQjtH",
-      "riotHandle": "@legend7341216:matrix.org"
+      "riotHandle": "@legend7341216:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 608,
       "name": "🦄🦄m-blockCompany🦄🦄",
       "stash": "J7Xp8kz4azNn3YiuAi5QGVZbzaAz7nC5YxUHWSEJT6ps7ut",
-      "riotHandle": "@sehun:matrix.org"
+      "riotHandle": "@sehun:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 609,
       "name": "happymeal",
       "stash": "Ez1CmvMtzcPbMLWd9SYPfEhVxeig98AgDEungZdb4931LCg",
-      "riotHandle": "@happymeal:matrix.org"
+      "riotHandle": "@happymeal:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 610,
       "name": "virto-col1",
       "stash": "DAx1gmPB5t1pU62nR5UmpiKWoKJxYKuiem5LrUbfZbkTenR",
-      "riotHandle": "@olanod:virto.community"
+      "riotHandle": "@olanod:virto.community",
+      "kyc": false
     },
     {
+      "slotId": 611,
       "name": "sofiia Validator",
       "stash": "Em4SALRPUSKodzt2MuTsnRaS1RcTd4K7mNYpjLpDy4qh4Hw",
-      "riotHandle": "@sofiia.kon:matrix.org"
+      "riotHandle": "@sofiia.kon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 612,
       "name": "mowgli",
       "stash": "GZTju5Z1jsoR7tguTD5cVPQFXNJ7wrmNuMRYoWhcv9m62wQ",
-      "riotHandle": "@man_cub:matrix.org"
+      "riotHandle": "@man_cub:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 613,
       "name": "helixstreet",
       "stash": "J6K1vA6ynGo2GrotGpP5ocHKr82JFTv7NUnzJcoRfTcCn8T",
-      "riotHandle": "@helixstreet.io:matrix.org"
+      "riotHandle": "@helixstreet.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 614,
       "name": "Crypto_Pepe_2",
       "stash": "Fjx8yqhGcNpq5tquyy5kRCqFgP1DdHEPJ6qyEZLEQxPRR48",
-      "riotHandle": "@chefireblade:matrix.org"
+      "riotHandle": "@chefireblade:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 615,
       "name": "ptg",
       "stash": "Hxhn1yrvik4FuKzd6pUSzccUNdhfdC1pfydssZrn8LkhFuw",
-      "riotHandle": "@ptg:matrix.org"
+      "riotHandle": "@ptg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 616,
       "name": "blockonaut",
       "stash": "Ff6vUSAEHy4K4BTjVdr6hqcgzWyqLnNAuUCoHFVmbM3L1RX",
-      "riotHandle": "@blockonaut_com:matrix.org"
+      "riotHandle": "@blockonaut_com:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 617,
       "name": "stakingland",
       "stash": "E676MBhv3aAWDK2Xo7y9BkuHkyja9PPr7jCYazYgDEF9AdV",
-      "riotHandle": "@erk773:matrix.org"
+      "riotHandle": "@erk773:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 618,
       "name": "ULTRA/N1",
       "stash": "GVGsDZBoccL1YFnJS8RCpYE6aT2sXZkKtfSTJhkXD2MBrmJ",
-      "riotHandle": "@ultranodes:matrix.org"
+      "riotHandle": "@ultranodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 619,
       "name": "Weak Alpha",
       "stash": "Ho9AmkG45n5oTNUrCJHhGxzYAACE4wVWX2DxMxjinZQLMTt",
-      "riotHandle": "@weaak.capital:matrix.org"
+      "riotHandle": "@weaak.capital:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 620,
       "name": "Weaak Beta",
       "stash": "GwNhKS2DqZZY8GGSroU9BaC4b6D8ikCpQ2ikiJRVbsUQYz8",
-      "riotHandle": "@weaak.capital:matrix.org"
+      "riotHandle": "@weaak.capital:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 621,
       "name": "kmv",
       "stash": "FPWddEqD2hHFFLtYNPCfbWdyW7rz4YHGQ867JCXsjEmKuRY",
-      "riotHandle": "@kmv:matrix.org"
+      "riotHandle": "@kmv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 622,
       "name": "kmw",
       "stash": "H4e8KspRDCS7YsZF4KJE9te31g9D3omhJobAadL5LGqDH7n",
-      "riotHandle": "@kmw:matrix.org"
+      "riotHandle": "@kmw:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 623,
       "name": "MUSHIKA",
       "stash": "H6zmh7cubJDTZhyjJkb3m8TBnZ5bXhnHvox5cyJesK2ddU9",
-      "riotHandle": "@browka:matrix.org"
+      "riotHandle": "@browka:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 624,
       "name": "ilona",
       "stash": "GnQzK44VvNCWQ3weUDMdUKqVrYGiC6jbrNytEP6VaBc51ML",
-      "riotHandle": "@ilona11:matrix.org"
+      "riotHandle": "@ilona11:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 625,
       "name": "Ka4ok1331",
       "stash": "DrKfoeBLqFUGWtq5C3aoKaYMP5kYn4gSuftUYYxnK8wQ9gu",
-      "riotHandle": "@ka4ok1331:matrix.org"
+      "riotHandle": "@ka4ok1331:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 626,
       "name": "MarketAcross-BB/2",
       "stash": "FUDBmPmHvoLnCtxbW55MhyYnhiN33CwtvFYux5CcfSSC8As",
-      "riotHandle": "@marketacross_bb:matrix.org"
+      "riotHandle": "@marketacross_bb:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 627,
       "name": "G3RQ0-000",
       "stash": "G6mhjB7yqXKXCqq5fJSRWnqp8vchfDEogiKL9jZt4BecNtF",
-      "riotHandle": "@g3rq0:matrix.org"
+      "riotHandle": "@g3rq0:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 628,
       "name": "G3RQ05",
       "stash": "ENaQfu9KHaTq4F8SrzZYaa6o1CrF2xrDCRGp4wArpYqFbib",
-      "riotHandle": "@g3rq0:matrix.org"
+      "riotHandle": "@g3rq0:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 629,
       "name": "AltOrderCap",
       "stash": "GNr651AniyecfsNBbxNJqRA2FwsEK8y4aU6dm42dTbXwkh9",
-      "riotHandle": "@alt.order:matrix.org"
+      "riotHandle": "@alt.order:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 630,
       "name": "stakingland2",
       "stash": "JKom8RqfizJKARAzrjkSNwfe1MLgvesCi6FiptU6Jh1MzsA",
-      "riotHandle": "@erk773:matrix.org"
+      "riotHandle": "@erk773:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 631,
       "name": "Perfect-node",
       "stash": "EaEcqkSUo1TVY4q3sz5uQLqdtpcgRm17qMHQko9cLKPH6RA",
-      "riotHandle": "@perfect-node:matrix.org"
+      "riotHandle": "@perfect-node:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 632,
       "name": "cyberG",
       "stash": "GAjCmzPYQySBaQ36YmBJxonQacRTBwxrfPP6ihgZMJGTwwy",
-      "riotHandle": "@xcyberg:matrix.org"
+      "riotHandle": "@xcyberg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 633,
       "name": "web34ever",
       "stash": "GL5jF2yxfVA499zNkjMEfiznhD2hJQX4s2Ega7fk93vt8qf",
-      "riotHandle": "@posthuman_dvs:matrix.org"
+      "riotHandle": "@posthuman_dvs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 634,
       "name": "SubStake✨",
       "stash": "HEHnVm4i3RAnayTtU7J7nqQjUvUkf6Vp4ckMB8mSX8vyV5P",
-      "riotHandle": "@kyleyoon:matrix.org"
+      "riotHandle": "@kyleyoon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 635,
       "name": "vika_validator",
       "stash": "EaNhNy9jwJoT842wkCYxuPoMhiw5g9deP5d7PX2r5AJtJYe",
-      "riotHandle": "@viktoriia.denisova:matrix.org"
+      "riotHandle": "@viktoriia.denisova:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 636,
       "name": "kopone",
       "stash": "D3F5XpKS18xgf8DUxeMuD29FBSM1qJPL6S55JnQWtHn7PdN",
-      "riotHandle": "@kopone:matrix.org"
+      "riotHandle": "@kopone:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 637,
       "name": "NOKOGIRISRV",
       "stash": "CsH4ZW4jRPZSH6JyDPQDkGZN3T3pvFstefXtfDnDihowHPj",
-      "riotHandle": "@nokogirisrv:matrix.org"
+      "riotHandle": "@nokogirisrv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 638,
       "name": "AlxVoy ⚡ ANODE TEAM ⚡ 1",
       "stash": "FUJdymoC7uCaxtE7hMf1HktCGAGNbniD7ebsZ3SNetLUeE2",
-      "riotHandle": "@alxvoy:matrix.org"
+      "riotHandle": "@alxvoy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 639,
       "name": "AlxVoy ⚡ ANODE TEAM ⚡ 2",
       "stash": "Eex9GNBwsvCfrNWvsahFbZdjiuNKyLSczcLcdwV85irifbs",
-      "riotHandle": "@m15putera:matrix.org"
+      "riotHandle": "@m15putera:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 640,
       "name": "Aringoty",
       "stash": "EM1wU9SBBMrqLYSrKqx6GjKQB1LzWMo1h61gYDUpxZksAzK",
-      "riotHandle": "@Aringot:matrix.org"
+      "riotHandle": "@Aringot:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 641,
       "name": "CARBONZERO3",
       "stash": "CmwjkPp55ZVoPjWz4uaLvsYY2xYE4PyVDJuPmmUiwCQijFm",
-      "riotHandle": "@shawneng:matrix.org"
+      "riotHandle": "@shawneng:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 642,
       "name": "blockops-validator-0",
       "stash": "HLsQZEMMN2cDN1cZBgMc48E2v1XergevtDZQ6Nueue7x2F9",
-      "riotHandle": "@haroldsphinx:matrix.org"
+      "riotHandle": "@haroldsphinx:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 643,
       "name": "Activator",
       "stash": "E5hWebLmPSFSUq3nSfGuFYopAK65fooqiXV91gQwuZGuMad",
-      "riotHandle": "@activatornode:matrix.org"
+      "riotHandle": "@activatornode:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 644,
       "name": "enby-collective-dominique-1",
       "stash": "GZeiCMQMMU3yPV2GMwZoiNvC1cqMWx7HTSBXeJsd27b3Wnj",
-      "riotHandle": ["@dominique:parity.io", "@enby:matrix.org"]
+      "riotHandle": ["@dominique:parity.io", "@enby:matrix.org"],
+      "kyc": false
     },
     {
+      "slotId": 645,
       "name": "slither_77",
       "stash": "FAgMinzMwXahWb6UAKPCGi4LfupFVyhatjK7oUhyZxRLYqH",
-      "riotHandle": "@erk773_1:matrix.org"
+      "riotHandle": "@erk773_1:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 646,
       "name": "Jesus Lives",
       "stash": "GqC37KSFFeGAoL7YxSeP1YDwr85WJvLmDDQiSaprTDAm8Jj",
-      "riotHandle": "@asteeber:matrix.org"
+      "riotHandle": "@asteeber:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 647,
       "name": "Begimotik",
       "stash": "G56GXDf11XFMLKDsyzRM7yZekiokZJfqtNgEF3sNdB6cbqT",
-      "riotHandle": "@Begimotik:matrix.org"
+      "riotHandle": "@Begimotik:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 648,
       "name": "ProfitGen",
       "stash": "GNoEBma3eRiXm9cF4erHzRnbJTbMC55KhxRP5xpUqm2pqFN",
-      "riotHandle": "@profitgen:matrix.org"
+      "riotHandle": "@profitgen:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 649,
       "name": "AltOrderCapBis",
       "stash": "G1dK9mW88ubm2MB6mqLNy7mKt7jrqzzDpWf5DsjCryKVqJs",
-      "riotHandle": "@alt.order:matrix.org"
+      "riotHandle": "@alt.order:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 650,
       "name": "MIDAS",
       "stash": "EyJgtqqbVsxArS7zuDq8rGTCA7m5WAqxv32msopPfWxwwpA",
-      "riotHandle": "@midas89:matrix.org"
+      "riotHandle": "@midas89:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 651,
       "name": "papa2307",
       "stash": "Drg6VcEh43rKxcrjFpSg6XZuQUAtR3t2Y3FTxyG7qz33RNG",
-      "riotHandle": "@denpub:matrix.org"
+      "riotHandle": "@denpub:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 652,
       "name": "zzBeq",
       "stash": "DAkLoGLEZ5wrfXBB5Htu84desmM6BNfdxyZjXGnt23957nK",
-      "riotHandle": "@zzBeq:matrix.org"
+      "riotHandle": "@zzBeq:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 653,
       "name": "Bison Stampede",
       "stash": "Dtdb7sR6NYGJbrHYqeW2ANwvY1mXSh1yuP2JHJm9ZmxMwyF",
-      "riotHandle": "@stampede_jon:matrix.org"
+      "riotHandle": "@stampede_jon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 654,
       "name": "GontaValidator_2",
       "stash": "Cs6cbyizgsfBnHtRY6pWZBnoVYrJAEmQE1ynWveivG2C4j2",
-      "riotHandle": "@gontajones:matrix.org"
+      "riotHandle": "@gontajones:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 655,
       "name": "WIN-WIN",
       "stash": "DSjjUzjk3gzV2mmGuBnEucNyxVuSY7d8FKdkjKw18bWWuDo",
-      "riotHandle": "@win-win:matrix.org"
+      "riotHandle": "@win-win:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 656,
       "name": "havik-kusama",
       "stash": "FQ4fiDSgVg556BoLYNjqM66qVei9ATbwNSuYbHHDvSF8Hb3",
-      "riotHandle": "@havik:matrix.org"
+      "riotHandle": "@havik:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 657,
       "name": "Gators-QB",
       "stash": "D4ios8nXiVpBbvNRYbi2frnybaikkcdMBFXcBBq7QaFrLKF",
-      "riotHandle": "@gators.validator:matrix.org"
+      "riotHandle": "@gators.validator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 658,
       "name": "Gators-RB",
       "stash": "JLi64F6mkc1G1ikuknKVpB2TvYDBrRKDfvKQFMp6JvvoLeG",
-      "riotHandle": "@gators.validator:matrix.org"
+      "riotHandle": "@gators.validator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 659,
       "name": "sofiia Validator2",
       "stash": "CuPaiAMDGZPvKmndepvT3tbRD7hGmbLoub51PYK3G1rQZ5S",
-      "riotHandle": "@sofiia.kon:matrix.org"
+      "riotHandle": "@sofiia.kon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 660,
       "name": "WIN-STAKE",
       "stash": "GAeLdHWKTas1G8ZX9wf2DwT5DKS5NvLwZhn1iRfcmyw7bLu",
-      "riotHandle": "@win-stake:matrix.org"
+      "riotHandle": "@win-stake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 661,
       "name": "SafeStake_IO_KSM02",
       "stash": "H1h4VJPKbk6XxhrxB3QGAonL7ZfGQeABucKHYykdZDxQSyw",
-      "riotHandle": "@safestake:matrix.org"
+      "riotHandle": "@safestake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 662,
       "name": "ArsGG",
       "stash": "FdA6PTtnr1yVfCv8RYqdSBfz1UhQFbfW12mn795L8zPaXhq",
-      "riotHandle": "@arsgg:matrix.org"
+      "riotHandle": "@arsgg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 663,
       "name": "STARDUST STAKING 02",
       "stash": "FPuQ4Ym3HzWuR3xoXvEwTY6hMdvdhCkYAZBfNv3mERpqGSJ",
-      "riotHandle": "@stardust-staking:matrix.org"
+      "riotHandle": "@stardust-staking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 664,
       "name": "STKD-02",
       "stash": "CpeX8UMVWUNJp5JrW7juUjfTtVhQENDApbAUKZ5AtQ36YmW",
-      "riotHandle": "@frazzled:matrix.org"
+      "riotHandle": "@frazzled:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 665,
       "name": "ichigo",
       "stash": "DMN8ijNCfdrbgir4hSS5jJZ8FxREerWs59ZW2faG8WE7BVB",
-      "riotHandle": "@ichigo94:matrix.org"
+      "riotHandle": "@ichigo94:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 666,
       "name": "tutifrutinode",
       "stash": "JHkKZ2XHsEqkeHousdrEmACYRW8uCRJMq2v99V1vx57hwZW",
-      "riotHandle": "@telutions:matrix.org"
+      "riotHandle": "@telutions:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 667,
       "name": "VALIDANDUM-IO | KSM | 02",
       "stash": "GrerymxmcLpdjdTsPzRiC8xEb2VeLYjY4onWh7dib29RA57",
-      "riotHandle": "@validandum.io.lee:matrix.org"
+      "riotHandle": "@validandum.io.lee:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 668,
       "name": "kagome-kusama-validator",
       "stash": "GZ777psWniwVo6gJV5T1ywnEy9UsQZEehWW5zu76A3Cco3z",
       "riotHandle": "@kamilsa:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 669,
       "name": "salenka 🌸",
       "stash": "GCbjDUscmiDd9fKmui2unzbDEA7VbCYRVXzTXhUGdc7ffat",
-      "riotHandle": "@salenka:matrix.org"
+      "riotHandle": "@salenka:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 670,
       "name": "RareShips1",
       "stash": "HfKp8e4cD8fKZPiN3B847VmFKmv9JuZE45ZqfVZeDxcjdBU",
-      "riotHandle": "@rareships:matrix.org"
+      "riotHandle": "@rareships:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 671,
       "name": "ichigo02",
       "stash": "ExACnQYbsZTNHb4kAhpA9YE7rYtD3BhrmPsExi64q3itVZN",
-      "riotHandle": "@ichigo94:matrix.org"
+      "riotHandle": "@ichigo94:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 672,
       "name": "Hamburg | validierung_cc 🇩🇪",
       "stash": "FDAugsNraejDeJHt8n4MSc5Gvn9zuAibNQ9qFQdGNVWYvtx",
-      "riotHandle": "@kev.funke:matrix.org"
+      "riotHandle": "@kev.funke:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 673,
       "name": "myhaletishe",
       "stash": "ESna9BQpJWuB34y9j2oJ7HM6MAfNniP9w4Fh4qQggc7WCPc",
-      "riotHandle": "@myhaletishe:matrix.org"
+      "riotHandle": "@myhaletishe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 674,
       "name": "Freshnode1",
       "stash": "FFqUGkoVNRvUmD1viecKj5hHWxnnKhC1gQVZUFcU8FdJBkq",
-      "riotHandle": "@freshnodek:matrix.org"
+      "riotHandle": "@freshnodek:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 675,
       "name": "Freshnode2",
       "stash": "J4f4CQtYLviz82KAaQeLe2UZpV9kLY98CjuXYzkBXb6wRQ6",
-      "riotHandle": "@freshnodek:matrix.org"
+      "riotHandle": "@freshnodek:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 676,
       "name": "djandre3",
       "stash": "EofzKajSeoukr8NabkTQaTnbdaPfoVuwf5gj6dLhiAFtGAE",
-      "riotHandle": "@djandre77:matrix.org"
+      "riotHandle": "@djandre77:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 677,
       "name": "lidertabores",
       "stash": "G83zrjcqZ5TAM7d4TXsWS8CPuxFHBj3nj5ZUogySfDeYqyJ",
-      "riotHandle": "@lidertabores:matrix.org"
+      "riotHandle": "@lidertabores:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 678,
       "name": "tutifrutinode2",
       "stash": "HTx1PeVsnWkz99GgByorr2L7jJ9j43XRR6y3Sc3sjre3o29",
-      "riotHandle": "@telutions:matrix.org"
+      "riotHandle": "@telutions:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 679,
       "name": "orlowski-io-kusama-validator-1",
       "stash": "GeiwmDpbdSpqRL6DGRwiBjkpeUPSYjBvYs8K94EyWbQMN8j",
-      "riotHandle": "@orlowskilp:matrix.org"
+      "riotHandle": "@orlowskilp:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 680,
       "name": "havik-kusama-01",
       "stash": "GSHE7p88bE7pZQQvzqrDmwowAsnVB7hRsnTLc8casD25hCw",
-      "riotHandle": "@havik:matrix.org"
+      "riotHandle": "@havik:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 681,
       "name": "KeyValidate",
       "stash": "FD9tqLqAXLYDDRcya1NjzQKgbYkrfLnDrn39cc6jmKgsbni",
-      "riotHandle": "@keyvalidator:matrix.org"
+      "riotHandle": "@keyvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 682,
       "name": "Satoyama-1",
       "stash": "J2JVgCJuVy5r22YsqYZT2fR1q1NDNgM5f3b51DRUgH1Tw96",
-      "riotHandle": "@shawneng:matrix.org"
+      "riotHandle": "@shawneng:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 683,
       "name": "ForklessNation2",
       "stash": "FyRsWF9bSQkK8TiJ1BdPoKtwvCwtZG7BYPoJFmZHVXnMDit",
-      "riotHandle": ["@synapticon:matrix.org", "@Darkstar/forklessnation:matrix.org"]
+      "riotHandle": [
+        "@synapticon:matrix.org",
+        "@Darkstar/forklessnation:matrix.org"
+      ],
+      "kyc": false
     },
     {
+      "slotId": 684,
       "name": "cryhel",
       "stash": "J9xpczE5TBP36bvZmiVfEyQ14XENTJrGPbRZ32FzbtJuKNL",
-      "riotHandle": "@cryhel:matrix.org"
+      "riotHandle": "@cryhel:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 685,
       "name": "Mystique",
       "stash": "GJWFwL8bxZszS5nJNWCV6vC5nBERLgscKSeNF3U9ZcQxL12",
-      "riotHandle": "@robin.hood:matrix.org"
+      "riotHandle": "@robin.hood:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 686,
       "name": "PROXFARM2",
       "stash": "EFS9pmTC9AvVKPgDEpi7WfGXuxYfmD67RGrDBM2miu7uJ7K",
-      "riotHandle": "@andreesken:matrix.org"
+      "riotHandle": "@andreesken:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 687,
       "name": "BigBallz K1",
       "stash": "HCcZdQVTGZdYUsySRtxS5dVPEsiL1H5yYRNnW3ftGcgqfeQ",
-      "riotHandle": "@bigballz:matrix.org"
+      "riotHandle": "@bigballz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 688,
       "name": "BigBallz K2",
       "stash": "CaLNLuRcnzA2fj3rtJFx3A4tC3SefBCZXEic97B77c4m5kG",
-      "riotHandle": "@bigballz:matrix.org"
+      "riotHandle": "@bigballz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 689,
       "name": "mysteps",
       "stash": "Ff9GB8ZhD92fr3TiQWKaUjNivi279LDxqbnsMVzm8zckvVs",
-      "riotHandle": "@myplan:matrix.org"
+      "riotHandle": "@myplan:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 690,
       "name": "SMART-KUSAMA ST",
       "stash": "GSL6QRhGA7SU2sNoF3gBvkWWPiPgSiRytHNZ7EmWF7itDSD",
-      "riotHandle": "@smartap:matrix.org"
+      "riotHandle": "@smartap:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 691,
       "name": "Prove Chain",
       "stash": "HySs45Fd2GKYk96bt4bWJeFxomNZYmhwsixdtbUJB5DvbLd",
-      "riotHandle": "@provechain:matrix.org"
+      "riotHandle": "@provechain:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 692,
       "name": "gurustaking_gksm_01",
       "stash": "F5j1j9TJ7xWePJmYh64Bf2b97pmer3mX1BsonCUpx3CJZpu",
-      "riotHandle": "@gurustaking:matrix.org"
+      "riotHandle": "@gurustaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 693,
       "name": "AAronn",
       "stash": "DBe4Bd4452xAdu9UxdNiyx9HS25TZSGzHK63ePdFK2ys2zA",
-      "riotHandle": "@AAronn:matrix.org"
+      "riotHandle": "@AAronn:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 694,
       "name": "Mehanikor",
       "stash": "Enu5SHWqWN7t6GU1HdnRDBALoqCcXVquk3j1kpoDYEpQnBf",
-      "riotHandle": "@Mehanikor:matrix.org"
+      "riotHandle": "@Mehanikor:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 695,
       "name": "Greanch",
       "stash": "F9wYAGszUHTfXvVXwRJV6385VxzkpaWQ98TUU3BCpPy4gXj",
-      "riotHandle": "@Greanch:matrix.org"
+      "riotHandle": "@Greanch:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 696,
       "name": "🧱 Seitan Block 🧱",
       "stash": "Da4rJvtEDGARwq81bC2NW97L53P5yJfKZCjsxu9XTQyCVBm",
-      "riotHandle": "@seitanblock:matrix.org"
+      "riotHandle": "@seitanblock:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 697,
       "name": "crypto-jack-sparrow-1",
       "stash": "Cbm8UMQYmgrhYt4KVah4rFyVE5MH1puA2AvBN3gYB2v2yGU",
-      "riotHandle": "@jacksparrowcrypto:matrix.org"
+      "riotHandle": "@jacksparrowcrypto:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 698,
       "name": "GRABBITY ✨🐇 K1",
       "stash": "DShgED7MWc9UrfcoofsFAcK6YJqRHpMYcfDk5odpM2C34FF",
-      "riotHandle": "@grabbity:matrix.org"
+      "riotHandle": "@grabbity:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 699,
       "name": "Synapticon ॐ The Magician",
       "stash": "Fk9aoXFmsScsnmhicKDQPnuJxvN9HAaHfepxoQcbEMPNP7D",
-      "riotHandle": "@synapticon:matrix.org"
+      "riotHandle": "@synapticon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 700,
       "name": "gurustaking_gksm_02",
       "stash": "ESE6ka6wGpXGDJ5ykjAvH1TTuAC9Dg5VFfc1dcfoEwX9qc1",
-      "riotHandle": "@gurustaking:matrix.org"
+      "riotHandle": "@gurustaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 701,
       "name": "pq",
       "stash": "E7ckMbPzh2s7ZRdn5ynSedo5DPWbNzojF3mg4sgHaquhqyE",
-      "riotHandle": "@pqhost5:matrix.org"
+      "riotHandle": "@pqhost5:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 702,
       "name": "itso",
       "stash": "HHLvigJ1dBiGVjKscDiCaWnZMSEi3PV1fBHB9DnEn7wU1VG",
-      "riotHandle": "@itso9943:matrix.org"
+      "riotHandle": "@itso9943:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 703,
       "name": "polkaorange",
       "stash": "CoLVrvRx43NPh8wtDMxY4UoNz1ebSwuu5FwegXj64kJaMkp",
-      "riotHandle": "@0xn00bz:matrix.org"
+      "riotHandle": "@0xn00bz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 704,
       "name": "PASTASTAKE 🍝 Carbonara",
       "stash": "E7qWwQx8Zvhu5HsjKDKnHVG7Sdy5cWpgavdLjUu8PHsb9CF",
-      "riotHandle": "@pastastake:matrix.org"
+      "riotHandle": "@pastastake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 705,
       "name": "BestValidatorEver4Ever",
       "stash": "HtzPM38QSyET73oECYBhajf128s98csmmUmtg1CzJM7zFKN",
-      "riotHandle": "@bestvalidatorever:matrix.org"
+      "riotHandle": "@bestvalidatorever:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 706,
       "name": "kristy",
       "stash": "GqAgkDmJ4CiUX4U8fVFCN5o1W2AQQtHzParjdTvsR7wJUmy",
-      "riotHandle": "@kristy:matrix.org"
+      "riotHandle": "@kristy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 707,
       "name": "BestValidatorEver007",
       "stash": "DHhU5qqjPSrfnATMM6dvzjEaJpgAaUYJY7CbvFPMJLG6Ssd",
-      "riotHandle": "@bestvalidatorever:matrix.org"
+      "riotHandle": "@bestvalidatorever:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 708,
       "name": "creeps",
       "stash": "G1qAFJH2JoNipx19Sup45rMYUmHupZraoGW67q9V5mpzo1b",
-      "riotHandle": "@creepskeep:matrix.org"
+      "riotHandle": "@creepskeep:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 709,
       "name": "APPLEPIE-KSM",
       "stash": "E7njcoMxryWRdeLuieJxsDWvnj4pDgJJ3Z7j5BCw8oZuMVX",
-      "riotHandle": "@kamelstaking:matrix.org"
+      "riotHandle": "@kamelstaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 710,
       "name": "Oracle",
       "stash": "DczAw1iwYjCftH3NJC1Cp3oXLxUbLSKnb4d2UrXNVLMKrgo",
-      "riotHandle": "@almario:matrix.org"
+      "riotHandle": "@almario:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 711,
       "name": "Endeavour",
       "stash": "D5XnQxmMaF7d2hfJdXXNvjyTDNyWGANCHy2kiQ16YMWHcHR",
-      "riotHandle": "@endeavour_1:matrix.org"
+      "riotHandle": "@endeavour_1:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 712,
       "name": "Space-Invader",
       "stash": "FDL99LDYERjevxPnXBjNGHZv13FxCGHrqh2N5zWQXx1finf",
-      "riotHandle": "@space_invader:matrix.org"
+      "riotHandle": "@space_invader:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 713,
       "name": "大善 ダイゼン daizen",
       "stash": "DTmuJeaumPsgdcbjtex1fWGw3u7CdCRhgpWwc6ryau4v1V6",
-      "riotHandle": "@daizen:matrix.org"
+      "riotHandle": "@daizen:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 714,
       "name": "F5",
       "stash": "GJEb4yszWSHdZFPjgBn8rWHXcmCWpzxeRAFUzSkEMUWQLj8",
-      "riotHandle": "@kusama2233:matrix.org"
+      "riotHandle": "@kusama2233:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 715,
       "name": "ADESERT-KSM1",
       "stash": "FASKqqTFEvdMKyMKgTdhHQF3qpF7XtEifYnP1brBX1mCyuG",
-      "riotHandle": "@kamelstaking:matrix.org"
+      "riotHandle": "@kamelstaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 716,
       "name": "stakemagnet-server-sksm|XA",
       "stash": "HKk5gnHuuePbKq6UbMn7sV3UxsifyZXyhYQqyrL8RPRBdq8",
-      "riotHandle": "@stakemagnet:matrix.org"
+      "riotHandle": "@stakemagnet:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 717,
       "name": "Stormius",
       "stash": "DUru5CsthS4dewpujsn4hn8UXK8jRdP2ipncerUyy1h99mv",
-      "riotHandle": "@stormius:matrix.org"
+      "riotHandle": "@stormius:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 718,
       "name": "Uvo technology",
       "stash": "DrnTwdksJxzKQx3kb7NXuWYGy4o8Uama3hiNvzcNBnj9LkZ",
-      "riotHandle": "@uvotech:matrix.org"
+      "riotHandle": "@uvotech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 719,
       "name": "wdmaster",
       "stash": "HZsquaFQ3rhBxBgEokxE4ea9gqpj2ZCyZGyXDojH8JYDuzS",
-      "riotHandle": "@wdmaster:matrix.org"
+      "riotHandle": "@wdmaster:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 720,
       "name": "validorange-ksm1",
       "stash": "J47U9wGuwzccFPoz8bnMTKJt7WGpPp8ZNgvtXFDL9PHwpCt",
-      "riotHandle": "@validorange:matrix.org"
+      "riotHandle": "@validorange:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 721,
       "name": "Inghazi-1-KSM",
       "stash": "FxkYQVJnqzfecyKsEd4XZckzJy6gRMADAfo6ZjCa1BcNHUD",
-      "riotHandle": "@inghazi:matrix.org"
+      "riotHandle": "@inghazi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 722,
       "name": "SMART-KUSAMA TT",
       "stash": "JGyCtf3AX8sewCkVUhcEqnLtRgiB1Sjjyrry5yxojLuxo9n",
-      "riotHandle": "@smartap:matrix.org"
+      "riotHandle": "@smartap:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 723,
       "name": "KUSAMABOX",
       "stash": "DGGDuUXKU7EGtPGu6hHykRqMeR2bGAJzgLzHGh7FJfrX1u4",
-      "riotHandle": "@antoniobox:matrix.org"
+      "riotHandle": "@antoniobox:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 724,
       "name": "StasRover2",
       "stash": "H9ZQyMjKZhMdioysqpQa7r3jEGxtfh3pLVKiZDjVxoA6JW3",
-      "riotHandle": "@ka4ok1331:matrix.org"
+      "riotHandle": "@ka4ok1331:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 725,
       "name": "💙💛 HUB UKRAINE POLKADOT 💙💛",
       "stash": "DQ2JCQDo7BtsxsBbURLK1djr3W3CQgumNys888pPmsF8XpU",
-      "riotHandle": "@polkadot_hub_ukraine:matrix.org"
+      "riotHandle": "@polkadot_hub_ukraine:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 726,
       "name": "Regho",
       "stash": "G4urZifj85pm9wXefakQwYfBW86C7cfnbZaLZzZSEnAZzGJ",
-      "riotHandle": "@regho_:matrix.org"
+      "riotHandle": "@regho_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 727,
       "name": "RanvierForkless",
       "stash": "Gv5KZ739bK3HBCDmNiKPRqoojSq4ZwzLyHrwfpdUEWJ87kR",
-      "riotHandle": "@dr.ranvier:matrix.org"
+      "riotHandle": "@dr.ranvier:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 728,
       "name": "KUSAMABOX2",
       "stash": "EMEavG21T6LHqinEJdNECX2Kvi5hDxYcvQtt2zy4u7eGKWx",
-      "riotHandle": "@antoniobox:matrix.org"
+      "riotHandle": "@antoniobox:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 729,
       "name": "📜 Holy Consensus 📜",
       "stash": "GhmAcucWFj6gnwJ4y61woEo1fbooXtpLRcLGnDJPuAvGCRB",
-      "riotHandle": "@mogioman:matrix.org"
+      "riotHandle": "@mogioman:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 730,
       "name": "stakemagnet-server-sksm|XB",
       "stash": "DaCVzWm7vqbJdRd9U9Cwgqx74DC9m1dasEXNTkftdAwwaRc",
-      "riotHandle": "@stakemagnet:matrix.org"
+      "riotHandle": "@stakemagnet:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 731,
       "name": "大善 ダイゼン daizen/2",
       "stash": "DjrNqGj6oQqwRi2RCffjwWAFctt2gAG9v9ikCthB77CTpdA",
-      "riotHandle": "@daizen:matrix.org"
+      "riotHandle": "@daizen:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 732,
       "name": "Brilliantine01",
       "stash": "GAhae9D5KtwmGDrsajvfom51i2EGgJDU41AcpfYPCPgzGUU",
-      "riotHandle": "@brilliantine:matrix.org"
+      "riotHandle": "@brilliantine:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 733,
       "name": "PowerLabs",
       "stash": "GAEP1qFK5eSpqarfRwW7h4ekPffp5Ydy2wZMZSWynho1zAd",
-      "riotHandle": "@powerlabs:matrix.org"
+      "riotHandle": "@powerlabs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 734,
       "name": "cargoksm",
       "stash": "H7CUfkTkp2heqHZWNw4Gic9n7tQSB29ZeTVPJgPd4CsUxi3",
-      "riotHandle": "@cargolevin:matrix.org"
+      "riotHandle": "@cargolevin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 735,
       "name": "polkatruffle",
       "stash": "HoxLWqRNR7jGxGjdaCHLA2xAfBqBHGX28LUnC4CL4uPejfa",
-      "riotHandle": "@0xn00bz:matrix.org"
+      "riotHandle": "@0xn00bz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 736,
       "name": "STAKELAND",
       "stash": "HePvh2WtXPUnAE8ECNPGYxjUDtiD9xmrUnDXoj1e2JmbwQe",
-      "riotHandle": "@stakeland:matrix.org"
+      "riotHandle": "@stakeland:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 737,
       "name": "Endeavour-2",
       "stash": "Fa75Eiok6WG1wC6TzC7DpYDrSswpNKkExcuaqqvuQRcrupe",
-      "riotHandle": "@endeavour_1:matrix.org"
+      "riotHandle": "@endeavour_1:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 738,
       "name": "validorange-ksm2",
       "stash": "DiSdjgV1fEu2i5wzxerBuuAWpypUQjAbt8WgLYWMZT4PGHj",
-      "riotHandle": "@validorange:matrix.org"
+      "riotHandle": "@validorange:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 739,
       "name": "arkawa",
       "stash": "JKkKXFGe1j5ALRnwnbWb7dnRhTrpTS2Hk7aPs9FRvZKB2js",
-      "riotHandle": "@akrawa:matrix.org"
+      "riotHandle": "@akrawa:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 740,
       "name": "040",
       "stash": "CuDEExW5brR4W55Ka7QdbopKDyUg5WEmr5BptP8ujL3qWNe",
-      "riotHandle": "@040net040:matrix.org"
+      "riotHandle": "@040net040:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 741,
       "name": "helixstreet/2",
       "stash": "13TunSyP6h8WRoukNYvqtG2pFWREWMjK2qt8r6g9VNhtUGmX",
-      "riotHandle": "@helixstreet.io:matrix.org"
+      "riotHandle": "@helixstreet.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 742,
       "name": "Vovik",
       "stash": "ESKkGVeid6pjL37e2PFugQJD2Q4FyUN3FZkmr9xb4XfbD5J",
-      "riotHandle": "@vovikpand:matrix.org"
+      "riotHandle": "@vovikpand:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 743,
       "name": "onevsone",
       "stash": "EfLb7PycrL88Gw9PpWaSmHLkevS2UTMYG1cWyWoxEEMM6X9",
-      "riotHandle": "@luddob671:matrix.org"
+      "riotHandle": "@luddob671:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 744,
       "name": "megatron",
       "stash": "FPJeeKkKhDE8uyid4MKvTj7KJNVczkobiDsxuMmrjPA4Wec",
-      "riotHandle": "@megatron72:matrix.org"
+      "riotHandle": "@megatron72:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 745,
       "name": "megatron-2",
       "stash": "FAcsFa8FcKRPXmsF9FXn9925crKnbfYVxJMyoDo1iPjUZ3j",
-      "riotHandle": "@megatron72:matrix.org"
+      "riotHandle": "@megatron72:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 746,
       "name": "Jekson",
       "stash": "EaVGoBHL6DsFwZGnvhn7JhafZgTuVRCWaEP3Q2gkgyvmfgZ",
-      "riotHandle": "@jekson23:matrix.org"
+      "riotHandle": "@jekson23:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 747,
       "name": "smile",
       "stash": "HLvv8uqSywsmrMkbH6hfHxXKH6wawfGQ3xwScQXZErejncw",
-      "riotHandle": "@smilex2007:matrix.org"
+      "riotHandle": "@smilex2007:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 748,
       "name": "lightning-strike",
       "stash": "CzPKgpYLTrhebtheB2GsM19WFtgH66fv9fjChuHGjzRyVpe",
-      "riotHandle": "@smoke26:matrix.org"
+      "riotHandle": "@smoke26:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 749,
       "name": "rodion",
       "stash": "DAnQRPv7SbVhchaVb7tkiYhFCFf8WhfQuH7LTJJSa8yxo6t",
-      "riotHandle": "@rodionpapa007:matrix.org"
+      "riotHandle": "@rodionpapa007:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 750,
       "name": "w3coins",
       "stash": "FnbQ2cex1tHitGVT4t1uXDgjUmV7e2XcPCkwfNuJ9dop8po",
-      "riotHandle": "@blackmatter:matrix.org"
+      "riotHandle": "@blackmatter:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 751,
       "name": "🌲🌳Plant Another Tree🌳🌲",
       "stash": "JEtreE266UaKiTe2BhKZ7cNGaJa98zy8JJP3QahGdDQuo9a",
-      "riotHandle": "@plant-a-tree:matrix.org"
+      "riotHandle": "@plant-a-tree:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 752,
       "name": "cyberG2",
       "stash": "DQLt8qTc4H4Vqba1DzTg7GWcu41V3zAXF6qrn6SiQVoAgrJ",
-      "riotHandle": "@xcyberg:matrix.org"
+      "riotHandle": "@xcyberg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 753,
       "name": "Statutory-002",
       "stash": "Cb8eMef4BPPVaKceqdJHLYxeTLY7tVJLbyQw2mcZ1UbKXe6",
-      "riotHandle": "@statutoryio:matrix.org"
+      "riotHandle": "@statutoryio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 754,
       "name": "Mantri Nodes",
       "stash": "G4R7xgGCuuxHpg17sxpwmUFFv4RATrpm4EMiTd8w3mCvjnp",
-      "riotHandle": "@mantrinodes:matrix.org"
+      "riotHandle": "@mantrinodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 755,
       "name": "🕴️ TUXEDO 🕴️",
       "stash": "FGHknsDq3UwZDgtvpGE6bK2Z1csVgrY5xCEA1H1kapZ8bxn",
-      "riotHandle": "@tux_in_tuxedo:matrix.org"
+      "riotHandle": "@tux_in_tuxedo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 756,
       "name": "🕴️ TUXEDO--Black 🕴️",
       "stash": "HEqt6SEaE6GZbAQQ3bWxjzmDbMhyx1HEj9sBUcs3N29Y1Em",
-      "riotHandle": "@tux_in_tuxedo:matrix.org"
+      "riotHandle": "@tux_in_tuxedo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 757,
       "name": "ABGAR",
       "stash": "GjrCYnVS59dsRkydpM6QSRLvpoR8MUPnkyVS3SNWqsxWW7r",
-      "riotHandle": "@abgar:matrix.org"
+      "riotHandle": "@abgar:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 758,
       "name": "andersen",
       "stash": "ESsiAML767Bxn8iXNLggxYCCBeuaysqVs86X6BY6zqXCmdT",
-      "riotHandle": "@andersen0707:matrix.org"
+      "riotHandle": "@andersen0707:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 759,
       "name": "bbewonderful",
       "stash": "Hvt16tq5pMsKDanoQmpBswMesbEdh9zWUHgCXaYhbFVmFD8",
-      "riotHandle": "@bbewonderful:matrix.org"
+      "riotHandle": "@bbewonderful:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 760,
       "name": "Faraday/1",
       "stash": "HLsPiB2amYFPFYMcYqKxGFLgDUVd4UP1kdA4QdZsH3e91LP",
-      "riotHandle": "@faradaynodes:matrix.org"
+      "riotHandle": "@faradaynodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 761,
       "name": "Faraday/2",
       "stash": "ET9CeDQKCoLaoESiXb6bzrwpdySs3BdT9C1FAtCUaHQq3nA",
-      "riotHandle": "@faradaynodes:matrix.org"
+      "riotHandle": "@faradaynodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 762,
       "name": "🌲🌳Plant A Tree🌳🌲",
       "stash": "JFHtREewUeVy96gGDwMTxrGvQxBDz6jGL8E5LxnAnNbcNbh",
-      "riotHandle": "@plant-a-tree:matrix.org"
+      "riotHandle": "@plant-a-tree:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 763,
       "name": "Nokogirisrv",
       "stash": "HvUaoMXAcKNe17zaXGAJvH9ugQk1PRAuzGMKvtck6DV7pvr",
-      "riotHandle": "@nokogirisrv:matrix.org"
+      "riotHandle": "@nokogirisrv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 764,
       "name": "web34ever-2",
       "stash": "EABjGLcjFpYUwy7WoSRgQzy3hMQEqLhdwvXDm8Xj13rhBJP",
-      "riotHandle": "@validator_posthuman:matrix.org"
+      "riotHandle": "@validator_posthuman:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 765,
       "name": "PathrockNetwork",
       "stash": "J6RxM7PgTM5c3tA9JCQdvoyHhkgWrNab2B4n5iDSprMTdSm",
-      "riotHandle": "@pathrock:matrix.org"
+      "riotHandle": "@pathrock:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 766,
       "name": "Nur so am rand-A",
       "stash": "GereCvo9Fiy7dA3N3DNQGPy2YWd6G1qpKBQNbYcTBCVdf8x",
-      "riotHandle": "@nursoamrand:matrix.org"
+      "riotHandle": "@nursoamrand:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 767,
       "name": "Nur so am rand-B",
       "stash": "Dw8xppg7t8JSsvq9PH1Soj2tvJ87AVGmeR97EKQUsSvnTEA",
-      "riotHandle": "@nursoamrand:matrix.org"
+      "riotHandle": "@nursoamrand:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 768,
       "name": "panvad",
       "stash": "CxaLLBqYFneSXx5vT4Mwe66paz8jae14BGY1xoucBj6De4G",
-      "riotHandle": "@panvad:matrix.org"
+      "riotHandle": "@panvad:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 769,
       "name": "ToneeForkless",
       "stash": "GniVGXA9ThPtoEqKx5xv9m5Zec586qWz7aMj4GWXskmzuMu",
-      "riotHandle": "@0xtone0x:matrix.org"
+      "riotHandle": "@0xtone0x:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 770,
       "name": "Aqupidhappy-K",
       "stash": "CpB85LvDDrcsgs9BgDfpUHPAcze4v2cCGHnNaW4yfKQLuP4",
-      "riotHandle": "@qupidvalidator:matrix.org"
+      "riotHandle": "@qupidvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 771,
       "name": "rainbow-axolotl",
       "stash": "HFdj9BdtXMXNKuheqq98Nxt1GtS4dTSBuE8houEc9EGmBkP",
-      "riotHandle": "@kokenaki:matrix.org"
+      "riotHandle": "@kokenaki:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 772,
       "name": "Blockchain Side1",
       "stash": "DQjtLa5eGpPVn1wUPFTUfQmuYmyvzffTde2JX65m4egeYin",
-      "riotHandle": "@sideblockchain:matrix.org"
+      "riotHandle": "@sideblockchain:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 773,
       "name": "Cryptography01",
       "stash": "E8hCYHcbVEcR1f8spXGe6EnEyd2JtwcUAqTTHw5fMnCxvf5",
-      "riotHandle": "@rhombusvalidator:matrix.org"
+      "riotHandle": "@rhombusvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 774,
       "name": "AppliedBC-KSM",
       "stash": "EVTu54Jg9PJZ9PqPCPu9VvKvQSMU88hmgeJ7pjmC9U745Qp",
-      "riotHandle": "@appliedbclabs:matrix.org"
+      "riotHandle": "@appliedbclabs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 775,
       "name": "AppliedBC-KSM-1",
       "stash": "GvCrPNycg1UHAaBAZ3BU3AeZAuzcdeFsvVWYTVoonZQRrtC",
-      "riotHandle": "@appliedbclabs:matrix.org"
+      "riotHandle": "@appliedbclabs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 776,
       "name": "w3coins/2",
       "stash": "CoYnH834695Znmqvtw9X317vKkLXvW3dCS6X3nvHsapLZfv",
-      "riotHandle": "@blackmatter:matrix.org"
+      "riotHandle": "@blackmatter:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 777,
       "name": "Magic Tab-2",
       "stash": "HUYaLWQANHf5jJwvyDkipvVphWwovJVgD4jzS3JFUHaqEaK",
-      "riotHandle": "@magictab:matrix.org"
+      "riotHandle": "@magictab:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 778,
       "name": "YAO Gmbh-02",
       "stash": "Fo6up1GipWicfDU5PePM4gg9yYEwvB1hf3J6LcXUUqFdhFo",
-      "riotHandle": "@lukayao:matrix.org"
+      "riotHandle": "@lukayao:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 779,
       "name": "DiamondII",
       "stash": "HLSNwrntJUaZbQ6Kc7uJdssd32DHP5nXKso7m6JwNvnrBcx",
-      "riotHandle": "@cryptographyvalidator:matrix.org"
+      "riotHandle": "@cryptographyvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 780,
       "name": "caveman",
       "stash": "EqbjvFvZZo11txeXQjzLdUfLWHCaXsY3k2gDydpnRrShkag",
-      "riotHandle": "@cavemaaan:matrix.org"
+      "riotHandle": "@cavemaaan:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 781,
       "name": "SMILE_STAKE",
       "stash": "H7ofPkmqC3xRqAsz3DVoqsdpKkisGaaqwUPp9pRBHZ12g2D",
-      "riotHandle": "@smile_stake:matrix.org"
+      "riotHandle": "@smile_stake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 782,
       "name": "cargoksm2",
       "stash": "HqoXDNxfG3QFPat6A8egrb75qhVL3zCbE6sxx393CyfWX9N",
-      "riotHandle": "@cargolevin:matrix.org"
+      "riotHandle": "@cargolevin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 783,
       "name": "Rhombus-2",
       "stash": "ED3aAecGouV9LgD952CNwJjnqZApYjBffWVmyqEV39rabqz",
-      "riotHandle": "@diamondvalidator:matrix.org"
+      "riotHandle": "@diamondvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 784,
       "name": "Blockchain Merlin1",
       "stash": "FJK3W4ArFkZFXdpHkBu4u4qN1YrDVea41yEZ89oEmFAvKn8",
-      "riotHandle": "@merlinvvs:matrix.org"
+      "riotHandle": "@merlinvvs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 785,
       "name": "Statute-2",
       "stash": "FcetKAtQKDYPQ3bNapXkRpTrqXQtbx8a6y8Jp2wfcZUnBhh",
-      "riotHandle": "@statute:matrix.org"
+      "riotHandle": "@statute:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 786,
       "name": "roadswithoutend",
       "stash": "JLBsB2Nh6Kg5AAtMat67BrjYEFkDkETtRc9hSnhvwCjkz5G",
-      "riotHandle": "@roadswithoutend:matrix.org"
+      "riotHandle": "@roadswithoutend:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 787,
       "name": "med0vyj",
       "stash": "GcdTqfCeMJFPFcBzsgjcC4ckV8tfBG8Kp3FzeEYJ52nEY7U",
-      "riotHandle": "@med0vyj:matrix.org"
+      "riotHandle": "@med0vyj:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 788,
       "name": "NovaSphere",
       "stash": "E2a7yoiDXAtb7REBKzqwGSY9SvoXqWfn1cBxnDD47GyFkMC",
-      "riotHandle": "@novasphere:matrix.org"
+      "riotHandle": "@novasphere:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 789,
       "name": "Smartconnection",
       "stash": "Cdgj8Te7A18wCWNWLcXYM2exjjxJbFmCZ79B2387d3jPRgb",
-      "riotHandle": "@smartconnections:matrix.org"
+      "riotHandle": "@smartconnections:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 790,
       "name": "Block shield",
       "stash": "DJYUrEpahAbXjQbrz9fYTZRHxVEGRyBC5iu6UFXfwqdczxP",
-      "riotHandle": "@blockshield:matrix.org"
+      "riotHandle": "@blockshield:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 791,
       "name": "Aqupidhappy-K-1",
       "stash": "CrmeF1REyE6B5oWYBZnewb8FZ9QcwdvNwRQimLepCt6fuBn",
-      "riotHandle": "@qupidvalidator:matrix.org"
+      "riotHandle": "@qupidvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 792,
       "name": "Mileruno",
       "stash": "HngY6Xx5TtsGcLWYC4N16gTVttH9p8pCpehrHUS9T1aaLia",
-      "riotHandle": "@Mileruno:matrix.org"
+      "riotHandle": "@Mileruno:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 793,
       "name": "goblinsama-2",
       "stash": "DVvbhRWcSarMt1kCkqiPedC9XwcDqetpsF73WUv32A2Sr5j",
-      "riotHandle": "@goblinsama:matrix.org"
+      "riotHandle": "@goblinsama:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 794,
       "name": "Gromzy",
       "stash": "Gq3wD3R2HqzDaJqtEY1koP7kUhg9sb51sbMC3FYBSJgCuhb",
-      "riotHandle": "@gromzy:matrix.org"
+      "riotHandle": "@gromzy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 795,
       "name": "Zuka",
       "stash": "F3AHXUCQ31dZ6vZ1PsJvUQSoonXUMS93qM6dRMK4T11uBp4",
-      "riotHandle": "@zuka_116:matrix.org"
+      "riotHandle": "@zuka_116:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 796,
       "name": "HYPERSPEED_1",
       "stash": "HRs3r9sUx16zv1ihw12ztch7a5gNFzuHnSx77HdXsHfEY1V",
-      "riotHandle": "@lokal:matrix.org"
+      "riotHandle": "@lokal:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 797,
       "name": "Validatrium 2",
       "stash": "GeQza19VnQmr9GhmLNqLRhHYFVAPfDeEEbZmUTuGfzL5cAe",
-      "riotHandle": "@denys_validatrium:matrix.org"
+      "riotHandle": "@denys_validatrium:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 798,
       "name": "lagartos",
       "stash": "Et8jw8wkybT7G36XbmeTtnjXx2TL2echLLLtfYS4quptmqR",
-      "riotHandle": "@lagartos:matrix.org"
+      "riotHandle": "@lagartos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 799,
       "name": "yellowbee",
       "stash": "FX89aERv2qbWRX5kVuTvEYHq4JfRvZqVvihKgcwYkkQcdfd",
-      "riotHandle": "@yellowbee267:matrix.org"
+      "riotHandle": "@yellowbee267:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 800,
       "name": "Valibrium",
       "stash": "HetEVryAvZ8m8QM2du43tQsULdYdXqHdDNA5kfGDLz3ybuT",
-      "riotHandle": "@valibrium:matrix.org"
+      "riotHandle": "@valibrium:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 801,
       "name": "Nejlepší volba",
       "stash": "EVfmda7AcM4dT8WHdw3PryrRCYVwwRoJQuF3Akc66KJTtZ5",
-      "riotHandle": "@petkomerko:matrix.org"
+      "riotHandle": "@petkomerko:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 802,
       "name": "MIDAS2",
       "stash": "CpF6D3kCL9u1ZvZrM1AC1chww6yBzK35zqixQstxFBqmCFw",
-      "riotHandle": "@midas89:matrix.org"
+      "riotHandle": "@midas89:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 803,
       "name": "dalmaDOT",
       "stash": "DDiisoLVB3MC9Z2vXkuupXPdkM3KzPbyBhydrenG3TFJYVh",
-      "riotHandle": "@dalmaDOT:matrix.org"
+      "riotHandle": "@dalmaDOT:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 804,
       "name": "ANGEL",
       "stash": "Gk3ySuvNK7KDPaFyG45vEXJkoYUT5SkrdsRv9BepdfPPVzm",
-      "riotHandle": "@dliseenko:matrix.org"
+      "riotHandle": "@dliseenko:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 805,
       "name": "bulls_and_bears",
       "stash": "CocAheZvSWyiq96Nh2REAGS7MnBXwrhzmDJPLZFNUefoqRm",
-      "riotHandle": "@bullsandbears:matrix.org"
+      "riotHandle": "@bullsandbears:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 806,
       "name": "Nokogirisrv-2",
       "stash": "J9WosJHzwwQc78vZA9oA8QoqEVGtNbDGX1XGT3JHcs5tEvC",
-      "riotHandle": "@nokogirisrv:matrix.org"
+      "riotHandle": "@nokogirisrv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 807,
       "name": "Delaney",
       "stash": "CdMEeN5ajikZr1jvY8aQg4nZY1nBaZBphDspt1ttaiypie8",
-      "riotHandle": "@delaney_sc:matrix.org"
+      "riotHandle": "@delaney_sc:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 808,
       "name": "🌌Novasama🌌/Einstein",
       "stash": "EtETk1FbrDg7FoAfkREuXT7xHxCjbEf28sBvWf6zfB5wFyV",
-      "riotHandle": "@solocrack_:matrix.org"
+      "riotHandle": "@solocrack_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 809,
       "name": "SILICONS",
       "stash": "Da298RGvXDht7C6EKioTnGc8dwT9sAjXraS79LJYgncLnZw",
-      "riotHandle": "@konti.konti:matrix.org"
+      "riotHandle": "@konti.konti:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 810,
       "name": "frogstakingnode#fksm#01",
       "stash": "EoUT1KcbyPJr5tDQkejjzHsF9p6EGP2c5Q8bYonvhZ7giY7",
-      "riotHandle": "@frogstaking:matrix.org"
+      "riotHandle": "@frogstaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 811,
       "name": "Loyal Validator",
       "stash": "FcGA1QJ8tfwgMFJuMutPcvPV911FELf4tbE2SMLejq6A6oc",
-      "riotHandle": "@loyal.validator:matrix.org"
+      "riotHandle": "@loyal.validator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 812,
       "name": "MUSHIKA2",
       "stash": "DmLEDRm7h1Y2bStXdbGuZ8mNVL4Bf2Bgd2tNTDM6QY4qWHv",
-      "riotHandle": "@browka:matrix.org"
+      "riotHandle": "@browka:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 813,
       "name": "Madbustazz",
       "stash": "GeqoXYixFsP9wLtfjDCrjmtHa47h4LEbxH1B46cBAm5uKq6",
-      "riotHandle": "@madbustaz:matrix.org"
+      "riotHandle": "@madbustaz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 814,
       "name": "Winterspring",
       "stash": "F5FqpNUCPEnsSme6i8jQ6q2Y7iCaMwKuqQDjcBczXwKyS2A",
       "riotHandle": "@winterspring:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 815,
       "name": "🌞 obis·dev 🌝",
       "stash": "HCdbYsBrTYWFu1tLNweEPfUPk268Nd4ZdjWmR3zh9WinpqW",
       "riotHandle": "@lobis:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 816,
       "name": "deigenvektor",
       "stash": "Dd93SeZZD6F8z68q7VNi2GdT8u1cgU5f2mTifA1f5v5A5km",
       "riotHandle": "@deigenvektor:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 817,
       "name": "deigenvektor/2",
       "stash": "F2WyUUFXLYnBg6acv7t2KFzH6D7CyNcvC4mRCwUdsHTUB4t",
       "riotHandle": "@deigenvektor:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 818,
       "name": "CroutonDigital-1",
       "stash": "DMPQfvTwBZHUA9D2WTUgWGU2CrTBaAgDwBdZVhbx1b8xFuv",
       "riotHandle": "@toxa3333:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 819,
       "name": "CroutonDigital-2",
       "stash": "D8U2vYu1vdvCaTMLV7gQuHyLhCUdzs79hwd4iugd8GhH9xj",
       "riotHandle": "@toxa3333:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 820,
       "name": "FLOWERSTAKE/01",
       "stash": "DweC7xmNqhUZWqvY7gvHaipb1cLyUYxEqfaiQBNduwHfjCS",
       "riotHandle": "@flowerstake:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 821,
       "name": "ENZORO-1",
       "stash": "Fw3GHC7YXT1MixGXbQWVbfT6ivmjDkeZDzY68ayjyg2B1Q8",
       "riotHandle": "@romanv18:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 822,
       "name": "ENZORO-2",
       "stash": "EaMgd5TMqMZ8LiJ3UW9T2vk3sSZaBGavsR88Zh7gdXEW18Y",
       "riotHandle": "@romanv18:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 823,
       "name": "DINOVAL🦖_NODE1",
       "stash": "Ci1wNS8S61ebNUbZeXgSoJG48unjC42RiYd2WmFJCaey83B",
       "riotHandle": "@dinoval:matrix.org",
       "kyc": true
     },
     {
+      "slotId": 824,
       "name": "Link swap-1",
       "stash": "DgJcKVBc2RLwS3NYiSKRZjNCi1H8vMm7R6Kdaot5VXohK3n",
       "riotHandle": "@dmitryevens:matrix.org",
       "kyc": true
-    },   
+    },
     {
+      "slotId": 825,
       "name": "Link swap",
       "stash": "F9tiZuYF4Z6X1nC8ca5gv5xEzBRMzbRkC2wcfNRPmzcTBiu",
       "riotHandle": "@dmitryevens:matrix.org",

--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -2259,7 +2259,7 @@
       "stash": "13unkT9DyFUnzKZdLCkHBvGLuhvcHQSrRhTWhrL9gqG98CTH",
       "kusamaStash": "J3f7ULfjVbbBYvZtMvaEDiUC8odXjt2A2hGShshBFCKHazY",
       "riotHandle": "@kureus:matrix.org",
-      "kyc": false
+      "kyc": true
     },
     {
       "slotId": 276,
@@ -2267,7 +2267,7 @@
       "stash": "13dTrEE587xf5Kwgiegg4bWfWEw4KRZcDpmFRw9jLBofvyMK",
       "kusamaStash": "JFHtREewUeVy96gGDwMTxrGvQxBDz6jGL8E5LxnAnNbcNbh",
       "riotHandle": "@plant-a-tree:matrix.org",
-      "kyc": false
+      "kyc": true
     },
     {
       "slotId": 277,
@@ -2275,7 +2275,7 @@
       "stash": "16cSiUTqGavZULqZStC6wvCxiFrtQmUafsDknoTmhAbMT6Jz",
       "kusamaStash": "FGHknsDq3UwZDgtvpGE6bK2Z1csVgrY5xCEA1H1kapZ8bxn",
       "riotHandle": "@tux_in_tuxedo:matrix.org",
-      "kyc": false
+      "kyc": true
     }
   ]
 }

--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -1,1724 +1,2281 @@
 {
   "candidates": [
     {
+      "slotId": 0,
       "name": "specialized-tarmac-3",
       "stash": "12bWp3rifCRrJzrTSPe1BrDaFxCLMVCUit6t21K986ZeeNJm",
       "kusamaStash": "HngUT2inDFPBwiey6ZdqhhnmPKHkXayRpWw9rFj55reAqvi",
-      "riotHandle": "@joe:web3.foundation"
+      "riotHandle": "@joe:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 1,
       "name": "🔒stateless_money🔒 / 1",
       "stash": "14Vh8S1DzzycngbAB9vqEgPFR9JpSvmF1ezihTUES1EaHAV",
       "kusamaStash": "HZvvFHgPdhDr6DHN43xT1sP5fDyzLDFv5t5xwmXBrm6dusm",
-      "riotHandle": "@aaronschwarz:matrix.org"
+      "riotHandle": "@aaronschwarz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 2,
       "name": "KeepNode-Carbon",
       "stash": "13BeUcLu7hzSTaoKpEtpdqiXKZz6yVfT9exKH6JuTW8RQQvJ",
       "kusamaStash": "FDDy3cQa7JXiChYU2xq1B2WUUJBpZpZ51qn2tiN1DqDMEpS",
-      "riotHandle": "@Drun:matrix.org"
+      "riotHandle": "@Drun:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 3,
       "name": "🔱-Masternode24-🔱",
       "stash": "14Q74NU7dG4uxiHTSCSZii5T1Y368cm7BNVNeRWmEuoDUGXQ",
       "kusamaStash": "FyRaMYvPqpNGq6PFGCcUWcJJWKgEz29ZFbdsnoNAczC2wJZ",
-      "riotHandle": "@alexkidd:matrix.org"
+      "riotHandle": "@alexkidd:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 4,
       "name": "Genesis Lab",
       "stash": "13K6QTYBPMUFTbhZzqToKcfCiWbt4wDPHr3rUPyUessiPR61",
       "kusamaStash": "DuRV4MSm54UoX3MpFe3P7rxjBFLfnKRThxG66s4n3yF8qbJ",
-      "riotHandle": ["@i7495:matrix.org", "@black_rock:matrix.org", "@pvdmitriy:matrix.org"]
+      "riotHandle": [
+        "@i7495:matrix.org",
+        "@black_rock:matrix.org",
+        "@pvdmitriy:matrix.org"
+      ],
+      "kyc": false
     },
     {
+      "slotId": 5,
       "name": "🍒 RYABINA 🍒 6",
       "stash": "1pKc7abu9Cm9YqoMeUFqdMBUxKJVuVUFPRcjpxcyKvjkx5m",
       "kusamaStash": "GxxV8DAcHCSzBbspu83AK9UoTYxzSQ6VVfdopjnkXfPtE8d",
-      "riotHandle": "@ryabina:matrix.org"
+      "riotHandle": "@ryabina:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 6,
       "name": "PDP_Validator",
       "stash": "16Y3FmTiJ3ZYAUZrf5rZtxrQJzcHsDBdscpu2zgMD2xN6NY7",
       "kusamaStash": "J7MmkYX4dJzUbNnU9ccemPFbxtsyaSgFVwAGMxx8k9Lf5cu",
-      "riotHandle": "@paveldp:matrix.org"
+      "riotHandle": "@paveldp:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 7,
       "name": "luguslabs-validator-1",
       "stash": "16aFDVsp6zd6VxUSgd34es3r23nWRkoj3NdLTS5Fk1Ez9MU1",
       "kusamaStash": "HKnRS3RryHjzTHGu42u6BtVp2cNuYoRVnrUJGeRAKqagsKY",
-      "riotHandle": ["@fbranciard:matrix.org", "@vladost:matrix.org"]
+      "riotHandle": ["@fbranciard:matrix.org", "@vladost:matrix.org"],
+      "kyc": false
     },
     {
+      "slotId": 8,
       "name": "🐑 Hodl_dot_farm A 🐑",
       "stash": "1sAkfdTH3cHAdJRYqMPNdeV7GhTKrddvMfkQrm3pQBABWrN",
       "kusamaStash": "D3bm5eAeiRezwZp4tWTX4sZN3u8nXy2Fo21U59smznYHu3F",
-      "riotHandle": "@hodl_farm:matrix.org"
+      "riotHandle": "@hodl_farm:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 9,
       "name": "◎◉ finalbits",
       "stash": "14NGUTHPtUvjbJttSF4qYmX8mUKk75UweWsL3GZyHw4ue2pv",
       "kusamaStash": "DmTzGAndAch8kXngopH69bcQCjYTukbp5Vh9SpJyiGfouwp",
-      "riotHandle": "@arifk:matrix.org"
+      "riotHandle": "@arifk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 10,
       "name": "NeNa 🌻",
       "stash": "131Y21vAVYxm7f5xtaV3NydJRpig3CqyvjTyFM8gMpRbFH1T",
       "kusamaStash": "GhNL9Mi5KiL3Ge2jv4jUdncipZNnUFALbzmwg8QqwjxJxcp",
-      "riotHandle": "@nametaken:matrix.org"
+      "riotHandle": "@nametaken:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 11,
       "name": "AGx1",
       "stash": "13ujCsf3t2YAdAhcpcEFVoJAPRYzMLHUHEnLroQp41sJCSnm",
       "kusamaStash": "DVasGX5qBMrCwNM8SnLyFrRpeniAwAsWe2noN6jPdx1jjao",
-      "riotHandle": "@agx10000:matrix.org"
+      "riotHandle": "@agx10000:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 12,
       "name": "StakedTech",
       "stash": "13j1gyUymLf1VYnE8BF5UKEcnoKf52nLQHjNDhe6wHzqNGHh",
       "kusamaStash": "FFRsm3haD645qfSVE1zfywYURWQ6z7YUAD4nad6Zw6qVxDk",
-      "riotHandle": "@veddoo:matrix.org"
+      "riotHandle": "@veddoo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 13,
       "name": "tsuki-validator-0",
       "stash": "14zGLKbiqsLHLoiT1vh7rEr556EW14Sci3dzv426eLSjapTR",
       "kusamaStash": "D3GpUSsNEnabe5mX8bCkq8Nnc9FVsZgb9nBbTjBq8t52GBg",
-      "riotHandle": "@nasamura:matrix.org"
+      "riotHandle": "@nasamura:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 14,
       "name": "Saxemberg2",
       "stash": "16UgRGtYLuDWsBvjLLtc6FYVB3qSCV9c4sidcN4zaFm9qCFR",
       "kusamaStash": "J19LYGghRCe4Ct3VW4Vz1amMoUgogS1sh2FQvPWroKcDdb1",
-      "riotHandle": "@s_saxemberg:matrix.org"
+      "riotHandle": "@s_saxemberg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 15,
       "name": "Binary Holdings 0001",
       "stash": "13UQKb6cQ3cvDTdMRTDcydUBmJ3cSYp64Y8R7Zenc29NZ39x",
       "kusamaStash": "HDbZDq8aW1pDbgzQcGK9Mzr8FnrRWHsoiXMSBVnoLwzy7HC",
-      "riotHandle": "@tacoturtle:matrix.org"
+      "riotHandle": "@tacoturtle:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 16,
       "name": "redpenguin",
       "stash": "15KDFYfFjdqhp3MDFEtHuyu9kLpXbT7k1zjx78MphViFdCaU",
       "kusamaStash": "G7mWyu1Pom5XreLHUzDEcvFp6WaMuLuo4QKxtDB9yJZnH69",
-      "riotHandle": "@redpenguin:matrix.org"
+      "riotHandle": "@redpenguin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 17,
       "name": "Ondin",
       "stash": "13ond4N8gejhNeYFxAiCtDymHvgsyQMW3L2kvKMEPtmvi3Cu",
       "kusamaStash": "HWAGAxX2PAzNVg7w3ZyTprH5yvwbVwQ8rbWwuZxtQKbQupW",
-      "riotHandle": "@ondin:matrix.org"
+      "riotHandle": "@ondin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 18,
       "name": "prematurata",
       "stash": "155tk9HmeJGsNZtA5LFasSCGZCdpAb2P2Gs6ej9JeP38sAww",
       "kusamaStash": "H72hS8xLmSiSBqbBXHND2KbN8PAoevi52B685cbGki6T9nt",
-      "riotHandle": "@prematurata:matrix.org"
+      "riotHandle": "@prematurata:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 19,
       "name": "Nodeasy",
       "stash": "12dvyqCFhVubTDqMdojyjhkxVUMaYVXWLv8uZW1NomUunPmN",
       "kusamaStash": "CczSz9z41uHpftVviWz91TgjLe3SmbvXfbAc958cjy7F6Qs",
-      "riotHandle": "@crabbean:matrix.org"
+      "riotHandle": "@crabbean:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 20,
       "name": "COSMOON",
       "stash": "15CosmEmAfQAhnxwan18e5TueAe6bDzrqqxg13dToDWr7A8M",
       "kusamaStash": "CmjHFdR59QAZMuyjDF5Sn4mwTgGbKMH2cErUFuf6UT51UwS",
-      "riotHandle": "@gregorst:matrix.org"
+      "riotHandle": "@gregorst:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 21,
       "name": "Staker Space [3]",
       "stash": "1NqVmUJCyaj5yZ9jp7ZZa58hbUx2QaBZ4eSCu9bqAdZXgAm",
       "kusamaStash": "FcjmeNzPk3vgdENm1rHeiMCxFK96beUoi2kb59FmCoZtkGF",
-      "riotHandle": "@gnossienli:matrix.org"
+      "riotHandle": "@gnossienli:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 22,
       "name": "dakkk",
       "stash": "12iqwZGB2sguEhjFi2ZRuWWixU8mHJnSiP1pwDefqGsBy4rV",
       "kusamaStash": "HX6qEdgi3eFMasuBwtVFLKKtKVJzHAAK17pLyB7SxkxCASD",
-      "riotHandle": "@dakkk:matrix.org"
+      "riotHandle": "@dakkk:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 23,
       "name": "Sio34",
       "stash": "16DJbUVKFJp6igLoDxCTPesE2DMgMmiawLXG9jsGpYNTshxt",
       "kusamaStash": "GCzeGccTUJaJSsUHWKaPb5AKiHP8oxm6jJsxDjMbEtNGf2H",
-      "riotHandle": "@sio34:matrix.org"
+      "riotHandle": "@sio34:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 24,
       "name": "🐰【 CRYPTIDS/FRANK 】🐰",
       "stash": "1StVBqjDJKogQTsLioHC44iFch1cEAv2jcpsnvsy5buBtUE",
       "kusamaStash": "JDEgrmpP97qu8UoTjm2Ra8wJUrXFrunabsnyQ2bZRspf9r6",
-      "riotHandle": "@cryptids:matrix.org"
+      "riotHandle": "@cryptids:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 25,
       "name": "Stakin 1",
       "stash": "14Uu59k5VLBz3zLMaEe3LBcqRLfKw2VJu2D3krxTssREjDJc",
       "kusamaStash": "DDdwYhRXzGWBvvaqMEQ7acJs21FiB96L7nnJZfq6HxseFxW",
-      "riotHandle": "@edwardl:matrix.org"
+      "riotHandle": "@edwardl:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 26,
       "name": "Mile-Bravo",
       "stash": "1HmAqbBRrWvsqbLkvpiVDkdA2PcctUE5JUe3qokEh1FN455",
       "kusamaStash": "HMaTJbeYonb2SoT7ek1sjrtkkKaor7j3yy2VUbj6FDokPXr",
-      "riotHandle": "@matherceg:matrix.org"
+      "riotHandle": "@matherceg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 27,
       "name": "ilgio",
       "stash": "15BZW721S3fzMYT8vY3Dt2sVXNTECqwHQ1bNUM8q4fi7EVcc",
       "kusamaStash": "Cdhjt72TSezVDkUzdgyoSwXByfwQJjuXSYcDs5L8snyB8Yx",
-      "riotHandle": "@ilgio:matrix.org"
+      "riotHandle": "@ilgio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 28,
       "name": "andreita-validator-0",
       "stash": "1247Twcyzmb46zNZ68yg3ZBPcsAfKRsxhTa2tkbPBs12gwXt",
       "kusamaStash": "EyTegKZ9DBvMkV6pMbjx2fRk3N2VLNNduuto1PGpYcEqRrX",
-      "riotHandle": "@andreita:matrix.org"
+      "riotHandle": "@andreita:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 29,
       "name": "Pioneer",
       "stash": "129LBt5T1eYtnGHbPYeiiMdmWfokCiiq7z6JBfjnYifiombz",
       "kusamaStash": "EQF693vsen6WxMdoYgf2cypvH4saFJWFzDupoFUT79MffeW",
-      "riotHandle": "@sachik0:matrix.org"
+      "riotHandle": "@sachik0:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 30,
       "name": "🏢 MIDL_dev_1",
       "stash": "1JoBYyPoUdsuU7vZi3KgQAaQYn6WhKqUDXRDmsaJ8Zgxr4T",
       "kusamaStash": "GyrcqNwF87LFc4BRxhxakq8GZRVNzhGn3NLfSQhVHQxqYYx",
-      "riotHandle": "@okp:matrix.org"
+      "riotHandle": "@okp:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 31,
       "name": "OnFinalityValidator",
       "stash": "15rb4HVycC1KLHsdaSdV1x2TJAmUkD7PhubmhL3PnGv7RiGY",
       "kusamaStash": "HRuaGanNmkmeQgZPWPXmkZJb944raNS5ni2vhKzhz75zVYP",
-      "riotHandle": "@ianhe:matrix.org"
+      "riotHandle": "@ianhe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 32,
       "name": "Melange",
       "stash": "13XkGCa13arfw4FkH8MVsvshrHrA9GuKPANjZ7xnjKCSg9fM",
       "kusamaStash": "EAhgtgo4qb6tbh3VwrPEgxne9qkwiqg5SzNHTmbqyoVyHk5",
-      "riotHandle": "@palace:tzchat.org"
+      "riotHandle": "@palace:tzchat.org",
+      "kyc": false
     },
     {
+      "slotId": 33,
       "name": "KIRA Staking",
       "stash": "15UyiZ9rYhrX39Rasc1iE4sdME7WHNFSj8RQT3yuuytd3Nrd",
       "kusamaStash": "HhcrzHdB5iBx823XNfBUukjj4TUGzS9oXS8brwLm4ovMuVp",
-      "riotHandle": "@kiracore:matrix.org"
+      "riotHandle": "@kiracore:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 34,
       "name": "Dionysus-sv-validator-0",
       "stash": "12CJw9KNkC7FzVVg3dvny4PWHjjkvdyM17mmNfXyfucp8JfM",
       "kusamaStash": "FWz717J6ATaYSNy2tRHAskEC9SP4uKHNJYC9mvfvimkB8GT",
-      "riotHandle": "@syed:web3.foundation"
+      "riotHandle": "@syed:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 35,
       "name": "KODAY",
       "stash": "15cfSaBcTxNr8rV59cbhdMNCRagFr3GE6B3zZRsCp4QHHKPu",
       "kusamaStash": "DayVh23V32nFhvm2WojKx2bYZF1CirRgW2Jti9TXN9zaiH5",
-      "riotHandle": "@day7:matrix.org"
+      "riotHandle": "@day7:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 36,
       "name": "Simply Staking",
       "stash": "13uwV8CBHjv25W3GACLPzzvTu2v9USc2yCQdhrqPhyM3vx6w",
       "kusamaStash": "DNDBcYD8zzqAoZEtgNzouVp2sVxsvqzD4UdB5WrAUwjqpL8",
-      "riotHandle": "@daniel-svc:matrix.org"
+      "riotHandle": "@daniel-svc:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 37,
       "name": "IL4R141",
       "stash": "12rgiL4r56kPE4PuYmz8snR21isfbrcp5Vbf8VdJe2AWDuus",
       "kusamaStash": "CmWzMp9is3LgQFWY6qtvkEUft57NXVVbXxKxarHjxPCrTtu",
-      "riotHandle": "@il4r141:matrix.org"
+      "riotHandle": "@il4r141:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 38,
       "name": "HashQuark",
       "stash": "15BQUqtqhmqJPyvvEH5GYyWffXWKuAgoSUHuG1UeNdb8oDNT",
       "kusamaStash": "D8BfryaM5xN62UuKUpLK5zbZEUSBtA76yP9YddQTKXi9pkB",
-      "riotHandle": "@lester:matrix.org"
+      "riotHandle": "@lester:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 39,
       "name": "Swiss Bond/2",
       "stash": "15ZvLonEseaWZNy8LDkXXj3Y8bmAjxCjwvpy4pXWSL4nGSBs",
       "kusamaStash": "EoYkgoLQn1GZrJLmqVMd6GhSJYWtYAtzg3fEcWH6nXjscqC",
-      "riotHandle": "@matteo_swissbond:matrix.org"
+      "riotHandle": "@matteo_swissbond:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 40,
       "name": "TigerPro Capital",
       "stash": "168HGqVpaHsEyeYH3kgLfYKXsATkp1ZYyo3p71ixcZM837jT",
       "kusamaStash": "HyZ3pc1LdxVkNSt2TYKc8vxp9PWexhz7ayL1WBUkfxxUJQb",
-      "riotHandle": "@tigerpro:matrix.org"
+      "riotHandle": "@tigerpro:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 41,
       "name": "SynerWork Inc",
       "stash": "13YNhNr6GU9YkHabngRx5SXMcwhPkXuzapywp7pyYtM9ktZS",
       "kusamaStash": "F7hDMvu33u14QPXbkBzqF4CuuyyruB2xi6D3V7aUbY8KGpr",
-      "riotHandle": "@synerwork:matrix.org"
+      "riotHandle": "@synerwork:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 42,
       "name": "ZENIT",
       "stash": "14MDvXHcSfZXacZR3nvbS4XYgpWi2dY65BnthsUnMZU6R1kH",
       "kusamaStash": "Gf7EHcqRZiXCELr2xYjQXrxAzVcEFh5pEjvQdedKS2avGAj",
-      "riotHandle": "@cash__:matrix.org"
+      "riotHandle": "@cash__:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 43,
       "name": "Everstake 2",
       "stash": "163GfMiFUuo4DWpnmqfW3T9uGoPYoEJrKZ2Q5XDWWwhgBAqA",
       "kusamaStash": "EMP286w89JTpvfRP2MKSWKgn9YiPw1JVTjmxdmVvcCzvim8",
-      "riotHandle": "@vit_everstake:matrix.org"
+      "riotHandle": "@vit_everstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 44,
       "name": "Jormungand_Labs🐍",
       "stash": "16YA8Y886DHxP3SgpY4Qws6BczY7cfJQQ41gFsPoK3N2YEoL",
       "kusamaStash": "G7xzXN3ddsqcsPswNKRhroyptEsh1oakjQ98K7fRZUTUvkr",
-      "riotHandle": "@mortgray:matrix.org"
+      "riotHandle": "@mortgray:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 45,
       "name": "hirish",
       "stash": "1627VVB5gtHiseCV8ZdffF7P3bWrLMkU92Q6u3LsG8tGuB63",
       "kusamaStash": "Eg19soJDW6GM387LPtrszyeQ93nuUZiGdUsbJbKqekKAPab",
-      "riotHandle": "@hirish:matrix.org"
+      "riotHandle": "@hirish:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 46,
       "name": "Mitch-Wariner",
       "stash": "16UvTJteZiHfoGjzMK5fAxwZd3wkbsFb2C1SKsMLCtxRhNWv",
       "kusamaStash": "FS8nKS5ReuaA999xUKTEzDDCA8BXyyrxD73KKyqwbRRt2Hf",
-      "riotHandle": "@mitch-wariner:matrix.org"
+      "riotHandle": "@mitch-wariner:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 47,
       "name": "ANAMIX",
       "stash": "15kkg1mK1tCGgqqo3c1CghtKCQsBEAPPjYNNmmRT3r29FeRX",
       "kusamaStash": "F7Wa1su7NRSr6LWuhPWdXcQALDyzm8Vmev7WtV5jVPtJELs",
-      "riotHandle": "@dbpatty:matrix.org"
+      "riotHandle": "@dbpatty:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 48,
       "name": "🧊 Iceberg Nodes 🧊 | V1",
       "stash": "14ices1G5qTmqhMfDVBECh4jotNDGTLu8fhE9YktWT3cLF2F",
       "kusamaStash": "Eices1KaGTYqiazfjJpwyjnz5UzqTxULeYqnmeJNz49gs19",
-      "riotHandle": "@icebergnodes:matrix.org"
+      "riotHandle": "@icebergnodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 49,
       "name": "YellowFin Tuna",
       "stash": "1TunGctS5HELfuJZjd5qBNoMVsST2EBdMw5vWK8f3dCFbq9",
       "kusamaStash": "CbaNLeJQ8e8aCJMTLa9euDKuTDmnT5oPmGFt4AmuvXmYFGN",
-      "riotHandle": "@bluefin_tuna:matrix.org"
+      "riotHandle": "@bluefin_tuna:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 50,
       "name": "CoinStudio",
       "stash": "16cT2wjqq18WJdNwzeDvm57GgiQHhaQeWCrA5ZUPyKhyujtF",
       "kusamaStash": "GCMGu8sjEuEZuMZavo5PLvAhr8fJXAty76jDV1YPquG9erp",
-      "riotHandle": "@coinstudio:matrix.org"
+      "riotHandle": "@coinstudio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 51,
       "name": "legos-x",
       "stash": "1PhQxnCXTCfDVBw3Ttbxa6DZJujV3YNFYpi4mFfLHyGWXD9",
       "kusamaStash": "EHAgisQqE3paxAC694qumC9QLmGSJTRT1vEMJ8FUK744ixS",
-      "riotHandle": "@legos:matrix.org"
+      "riotHandle": "@legos:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 52,
       "name": "Ruby",
       "stash": "13mjnUDrHwYGATFB1FkFkZ1U3kYFsAQfHYTdcc8p3HP1xzZA",
       "kusamaStash": "G543pxmwKNAbW2WepZW7Ss9Wgx9wuDQWcPyhk4eEzpzcibG",
-      "riotHandle": "@tatan:matrix.org"
+      "riotHandle": "@tatan:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 53,
       "name": "PureStake_Polkadot_01",
       "stash": "14yx4vPAACZRhoDQm1dyvXD3QdRQyCRRCe5tj1zPomhhS29a",
       "kusamaStash": "DVw4Zkfva2MPibAsr8vgoha1T2ow8zreoTWGyBDioQBdfMM",
-      "riotHandle": ["@artk:matrix.org", "@mitchell-g:matrix.org"]
+      "riotHandle": ["@artk:matrix.org", "@mitchell-g:matrix.org"],
+      "kyc": false
     },
     {
+      "slotId": 54,
       "name": "Northwoods-C",
       "stash": "162Cw32opH6PQRLU1dcLVgkvgC3EWrTFZQfjCK9kbuFYZ76p",
       "kusamaStash": "HZU7Hkai2LZkP6BRCUEWiGSkhaNJoaPgroYEKtKkMHwTTY6",
-      "riotHandle": "@northwoods-support:matrix.org"
+      "riotHandle": "@northwoods-support:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 55,
       "name": "nicasio-201",
       "stash": "13zBFyK97dg4hWjXwEpigeVdu69sHa4fc8JYegpB369PAafq",
       "kusamaStash": "GCporqtiw7ybKYUqAftjvUAjZnp3x9gfrWsTy1GrvrGwmYT",
-      "riotHandle": "@zeke:matrix.parity.io"
+      "riotHandle": "@zeke:matrix.parity.io",
+      "kyc": false
     },
     {
+      "slotId": 56,
       "name": "NEWDEAL",
       "stash": "16CdHjb4nxVwF6uwmPm6A29pc4ubnLiY7UqasMxt7cT9BcoK",
       "kusamaStash": "DMkKL7AZw9TkNw2NaBdocmFRGUG8r8T4kdGGcB13fv2LARy",
-      "riotHandle": "@paride_f:matrix.org"
+      "riotHandle": "@paride_f:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 57,
       "name": "Staking4All 1KVP",
       "stash": "16g43B7VPfTmpXQujSz3aKbqY9twSrDreHFWtwp4P7bLkQPp",
       "kusamaStash": "GTUi6r2LEsf71zEQDnBvBvKskQcWvK66KRqcRbdmcczaadr",
-      "riotHandle": "@staking4all:matrix.org"
+      "riotHandle": "@staking4all:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 58,
       "name": "BlockAegis",
       "stash": "1EWbJs2jdh34mhH8ovwQTNiLmQ87mMksJW3raRMxk6WXY29",
       "kusamaStash": "HcdBFbGDMFzs5MuYQxFQpTBivHgH1UyFKqQDip9YgmqngKH",
-      "riotHandle": "@porter92:matrix.org"
+      "riotHandle": "@porter92:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 59,
       "name": "BladeRunner",
       "stash": "13J6LkvsEtdZpvRwUMVNbag26md9ycmGe5PM8UnEokhL6Tgk",
       "kusamaStash": "CpYNXnYC1mPPRSXMHvm9EUuhEqHjvj6kCN4kshqMdEpPYSF",
-      "riotHandle": "@d3ckard:matrix.org"
+      "riotHandle": "@d3ckard:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 60,
       "name": "Polkadotters",
       "stash": "16A4n4UQqgxw5ndeehPjUAobDNmuX2bBoPXVKj4xTe16ktRN",
       "kusamaStash": "FVAFUJhJy9tj1X4PaEXX3tDzjaBEVsVunABAdsDMD4ZYmWA",
       "riotHandle": "@pmensik:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 61,
       "name": "Zetetic Validator 1",
       "stash": "16Ar9KjX2LQf2CdTrTxbyxPjDNswhL7qPhnwcr8ocMynBRWo",
       "kusamaStash": "GD6MTUJG9Ym7tS6PLF42yreHpqpvFgPcqPwcyRGiMv2TSGR",
-      "riotHandle": "@zeteticvalidator:matrix.org"
+      "riotHandle": "@zeteticvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 62,
       "name": "STAKE LINK 001",
       "stash": "1sh6y8SMuseeuxn8JyW4eUHbJrLevi7ASH1TJQqb3DFjAYe",
       "kusamaStash": "GetZUSLFAaKorkQU8R67mA3mC15EpLRvk8199AB5DLbnb2E",
-      "riotHandle": "@stakelink:matrix.org"
+      "riotHandle": "@stakelink:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 63,
       "name": "Eat Pray Validate 1 🍴🙏🖥",
       "stash": "1BdoL1BP36SZGEKR4iX8ksou2GTnrDd5of99SWK82c3A4aB",
       "kusamaStash": "EPV1c7jjoCFPkWqTzTkbuT3oGRM8HkjbTVHeuvsyiAbB2aZ",
-      "riotHandle": "@yx11xy:matrix.org"
+      "riotHandle": "@yx11xy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 64,
       "name": "CryptoLab",
       "stash": "16iiKwFsRKRsjAiEpD4zgNgEX84nzHtHHNFKXhz1sHtan3ne",
       "kusamaStash": "GCNeCFUCEjcJ8XQxJe1QuExpS61MavucrnEAVpcngWBYsP2",
-      "riotHandle": "@yaohsin:matrix.org"
+      "riotHandle": "@yaohsin:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 65,
       "name": "TheGuild",
       "stash": "16HvKyV9B61hsop3ZY6pWYeV537S29kd9pb9FMrPzx49ym5X",
       "kusamaStash": "Gnn9xyFiZYXtKeMfZSSWSdSvxv9go1KCq2kgfyyGcAoZ3pL",
-      "riotHandle": "@theguild:matrix.org"
+      "riotHandle": "@theguild:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 66,
       "name": "🐲 DragonStake 🐉",
       "stash": "1dGsgLgFez7gt5WjX2FYzNCJtaCjGG6W9dA42d9cHngDYGg",
       "kusamaStash": "DSpbbk6HKKyS78c4KDLSxCetqbwnsemv2iocVXwNe2FAvWC",
-      "riotHandle": "@derfredy:matrix.org"
+      "riotHandle": "@derfredy:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 67,
       "name": "GontaValidator_1",
       "stash": "1UQC7Vs4zbywp8CbxcCCRUyyRqeUZxq9aXeD8UZ3MpLUy12",
       "kusamaStash": "D3ii6afqaMSFvw8R2NExE1qGQ8EawDsXTduSVm9y51K3Jnb",
-      "riotHandle": "@gontajones:matrix.org"
+      "riotHandle": "@gontajones:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 68,
       "name": "XUAN_NODE",
       "stash": "13rkfSaFsMEFJAV1wcQcnbJnxiigJTb78qkkLSEvUNPA2QVZ",
       "kusamaStash": "HvumdQbk47PXTz57UDrZP5n8rmgf27upC1ooPjtZf9XA2Wk",
-      "riotHandle": "@xuan93:matrix.org"
+      "riotHandle": "@xuan93:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 69,
       "name": "🚀 PolkaStats",
       "stash": "15psTaipmWG86U5vNkF7Guv9TRPMRLKHkGS8cXT74v3RCC5t",
       "kusamaStash": "GTzRQPzkcuynHgkEHhsPBFpKdh4sAacVRsnd8vYfPpTMeEY",
-      "riotHandle": "@mariopino:matrix.org"
+      "riotHandle": "@mariopino:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 70,
       "name": "🏢 Ministry Of Blocks 🏢",
       "stash": "15dTancD5HTn3Zn5RcgojF76znNu9HrpTtBTBGc5oPBDfxBy",
       "kusamaStash": "D2r9AudNkHHpKfGtS5rpVHkchBoBhRsR6TmNcTuU4yiTp6w",
-      "riotHandle": "@slavamo:matrix.org"
+      "riotHandle": "@slavamo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 71,
       "name": "Algo Stake / Cerulean One",
       "stash": "15KX9B5ksRHq3vw1Un4D7DvrodZqoS2FLkZV38CSkR4FnZjh",
       "kusamaStash": "EPhtbjecJ9P2SQEGEJ4XmFS4xN7JioBFarSrbqjhj8BuJ2v",
-      "riotHandle": "@shadewolf:matrix.org"
+      "riotHandle": "@shadewolf:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 72,
       "name": "Logan",
       "stash": "1LohyWj5cEmH1teF3bAMvR4DLTJNL1PHWWz7nzHRgo59qPd",
       "kusamaStash": "FkWQJswxegj5BSuRULMiw6i79NawgC2ZhqRtoeaLY2xFk2W",
-      "riotHandle": "@logantg:matrix.org"
+      "riotHandle": "@logantg:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 73,
       "name": "stake_su",
       "stash": "1ZHNWmKsVHCS528yKDteRPpnx5hTrGUZvyjEpvaWppKDiPt",
       "kusamaStash": "D5p4fKuhggjXRxiZ4JuPTCGYpDM6Dp9VRxjsYCeVg7LYv5a",
-      "riotHandle": "@mr.ownage:matrix.org"
+      "riotHandle": "@mr.ownage:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 74,
       "name": "REPE",
       "stash": "15AvEyVsAjcmWFnTNmzvF1gkvd1x1P6uFp3u8wLa6wxX3294",
       "kusamaStash": "FaBN1AxtJu21x2cUqvdF5VcVUAfzfqyvJPvwgsdwo3pkdr9",
       "riotHandle": "@repe:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 75,
       "name": "CertHum-MaxStake-sv-validator-0",
       "stash": "168xfZuHXv13uyrVV2vADpuMa4B3kAtj11gRNHA8YKRH9xuW",
       "kusamaStash": "EpeeGt1x3kju8TZmfcaHTkBwTn7eyq4Sxy8Z3dPU88chMcN",
       "riotHandle": "@certhum-jim:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 76,
       "name": "NOVY",
       "stash": "16SSTPeD2UW3hhnuRBS6HjpxhzRFBrRf2Wupxf1iJgMkhBSD",
       "kusamaStash": "Cs7UFcNBsBV4Y65GsM3bDzpvinMKFQZyt6x9TrhVhc8ps4E",
-      "riotHandle": "@novy4:matrix.org"
+      "riotHandle": "@novy4:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 77,
       "name": "Dox-Dot-02",
       "stash": "13foHgXdzr1agokV6Ed9CBHGQG1NpBqvqhmUL7rojcBUBzvq",
       "kusamaStash": "F8H3cT1XKWHbkWSRhyVbRgpqn1nLhXGCL1uUdXQJmavpACQ",
-      "riotHandle": "@paradoxxx:matrix.org"
+      "riotHandle": "@paradoxxx:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 78,
       "name": "🚀PromoTeam🚀 | Validator",
       "stash": "12BkPLskXyXrHhktrinLxVFkPzzvCzCyVCaqHkUEoxMwSzeq",
       "kusamaStash": "Dm4uKxZJZHJbpZpfnYPiHnbgyHWKMU1s5h6X7kqjfYv1Xkk",
-      "riotHandle": "@alex-m:matrix.org"
+      "riotHandle": "@alex-m:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 79,
       "name": "GoOpen",
       "stash": "16VVNbc4m6aUxwaVwgRra6Ue7fMNGcRQHTFo1TqxmnCyuwwn",
       "kusamaStash": "JJiV1xrj1814BVDDG2pFCsgzdbR7K29VcyXQGXEUhn7LWhK",
       "riotHandle": "@alko89:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 80,
       "name": "polkadot golunar 001",
       "stash": "12Czh4LvGEf1AmD6R5t4tFwvq3ZVfBJtJAkxqKkBCB7yYGsg",
       "kusamaStash": "HiM83FqHQBUmJJnYWdXRcP13e5HNggx7APvzHegUYv4aCvc",
-      "riotHandle": "@cryptogolunar:matrix.org"
+      "riotHandle": "@cryptogolunar:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 81,
       "name": "stakeops0-sv-validator-0",
       "stash": "1DxKCXhiAJU6PD2Kg5g64GDCYXUuanDzqdGsytm9QtvYH32",
       "kusamaStash": "GCcy5CqhjQ3Ur1FZBZTc13Y3BwH1d1GNcSucz2knL85gxc6",
-      "riotHandle": "@hval:matrix.org"
+      "riotHandle": "@hval:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 82,
       "name": "SEKOYA LABS",
       "stash": "15PeEsbJeU2BZDgoCmo6xdzsuRaZv1PxLaCUyFmfWPwkZPJ4",
       "kusamaStash": "J73TGAeL5U5SFMmMB3fS9gxcGKMS9gsHTyhrFQg8Lx9gfhA",
-      "riotHandle": "@stewartv:matrix.org"
+      "riotHandle": "@stewartv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 83,
       "name": "Stakely",
       "stash": "15R1Th3ULXAq81QPGeEDfE1ywbw19AjZiARxH7czm83wS2w2",
       "kusamaStash": "EfcQCKZJaNu2vcrpnJDCoh1ub4mGWcHVzeU8ghUH7Co9rui",
-      "riotHandle": "@iicc1:matrix.org"
+      "riotHandle": "@iicc1:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 84,
       "name": "Ancibanci",
       "stash": "11AnciffJctDC28odTEjDVYP2yWyp6275WLbrAUHi2vJm9f",
       "kusamaStash": "DaNCiojAyKWjXDLxiHLrpMvD36hgKpvrYD3Xqf31RNDqXKT",
-      "riotHandle": "@ancibanci:matrix.org"
+      "riotHandle": "@ancibanci:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 85,
       "name": "STAKINGDX_COM",
       "stash": "155Uc2YERq1vYYcS2owKa3vZk2zyehP624JzX5frkJkPY7db",
       "kusamaStash": "FeuqakbGhvLMwvpqxocPounn7xbLR1xJN4U6fK1ibeJbuh8",
-      "riotHandle": "@stakingdx:matrix.org"
+      "riotHandle": "@stakingdx:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 86,
       "name": "polkadot-badger-validator-01",
       "stash": "12bSXHhe5qn7TCJms4EUNFUVA4jcPRa9FnJxGZBSJuLKJ9hy",
       "kusamaStash": "DG1TPMPi6haZsUUgXSoMwNsUW198EXBu7Wd7EGU1KdfEag1",
-      "riotHandle": "@lilok:matrix.org"
+      "riotHandle": "@lilok:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 87,
       "name": "Stampede-Bison",
       "stash": "12KK58ncKnnozV3MjmtTGMr6dZjBR5Ryc2Gm4v2ADrayoLQd",
       "kusamaStash": "JBwJ33SrTv6jFZroGBWNdpR2Kat3GW5CfSvhDFqvwxLUU4C",
-      "riotHandle": "@stampede_jon:matrix.org"
+      "riotHandle": "@stampede_jon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 88,
       "name": "ALESSIO",
       "stash": "16cdSZUq7kxq6mtoVMWmYXo62FnNGT9jzWjVRUg87CpL9pxP",
       "kusamaStash": "GaK38GT7LmgCpRSTRdDC2LeiMaV9TJmx8NmQcb9L3cJ3fyX",
       "riotHandle": "@ironoa:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 89,
       "name": "polkachu-polkadot-1",
       "stash": "15ym3MDSG4WPABNoEtx2rAzBB1EYWJDWbWYpNg1BwuWRAQcY",
       "kusamaStash": "CsKvJ4fdesaRALc5swo5iknFDpop7YUwKPJHdmUvBsUcMGb",
-      "riotHandle": "@songhua:matrix.org"
+      "riotHandle": "@songhua:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 90,
       "name": "🗻Basecamp-Matterhorn🗻",
       "stash": "14TFu7nqzcSnoEN7cSX8JGLtNejb69iSdsbVpt4CA29rXQwo",
       "kusamaStash": "D4NNrK9KchcZr4qJxYREHjWNU4wW92VDy9ieHnRz1ySy32Z",
-      "riotHandle": "@wolfstrom27:matrix.org"
+      "riotHandle": "@wolfstrom27:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 91,
       "name": "ryanhigs",
       "stash": "15dFHJonu6cGqv8UMhrZPpomAtqpGtwnb2Ar7fRCq91BZtVq",
       "kusamaStash": "HLsh79QY2bnA5URc9jrxwwH6xvnqbzU59HDpgrJNgwLsdct",
-      "riotHandle": "@ryanhigs:matrix.org"
+      "riotHandle": "@ryanhigs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 92,
       "name": "Uno Staking",
       "stash": "1cFsLn7o74nmjbRyDtMAnMpQMc5ZLsjgCSz9Np2mcejUK83",
       "kusamaStash": "ERrC6KGicLk5zqhPjzVPWTEz6Vi9P7mW1cwKxDTyXcFEqRb",
-      "riotHandle": "@unostaking:matrix.org"
+      "riotHandle": "@unostaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 93,
       "name": "Ubik Capital",
       "stash": "15iwm1HrcGiTZoZenijMTCayRD3hM2RpKde3LrrNxPKAMjTg",
       "kusamaStash": "DwJnksma9utUsT31bzf7eUwkDBetZhFzD3bJLE1uBZ5udHN",
-      "riotHandle": "@anuntjocuri:matrix.org"
+      "riotHandle": "@anuntjocuri:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 94,
       "name": "cryptobees-validator",
       "stash": "16zgGRrNMKBfz5CGJgvAmkavER9T8syxVBELqVA8SMLP3gm",
       "kusamaStash": "Hg5nkQvtyrKvvP3dBP1hDRWhjtVB7uxsrjSFemH3np7GdJY",
-      "riotHandle": "@cryptobee:matrix.org"
+      "riotHandle": "@cryptobee:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 95,
       "name": "lunar_dot",
       "stash": "12RXTLiaYh59PokjZVhQvKzcfBEB5CvDnjKKUmDUotzcTH3S",
       "kusamaStash": "CroiANffLtjz44LXp98NqmLxuUW5xxbsruZiRUXdeGFD82a",
-      "riotHandle": "@lunar_dot:matrix.org"
+      "riotHandle": "@lunar_dot:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 96,
       "name": "COMPUTECRYPTO",
       "stash": "15JjaHXBC6whzYhWiEi7uExsTboAC4tibbeBKPxh5CVk5Jfq",
       "kusamaStash": "Gpvr66V61fabb5UzuYoCyJLUjPNaQ7LRwjNuQHgyBraq5Ww",
-      "riotHandle": "@computecrypto:matrix.org"
+      "riotHandle": "@computecrypto:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 97,
       "name": "🚂 Zugian Duck 🦆",
       "stash": "15jrQX54HczCKJgtYYoKvzJ2kgyCyyA4kyvMv2bC8x9UtDpn",
       "kusamaStash": "HCAYcNgeMLCXjg9ifeJc6uBaesPv9WHMLm4XT45sqMK2h1H",
-      "riotHandle": "@robert:web3.foundation"
+      "riotHandle": "@robert:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 98,
       "name": "stakepile_1",
       "stash": "124X3VPduasSodAjS6MPd5nEqM8SUdKN5taMUUPtkWqF1fVf",
       "kusamaStash": "J6TTn21p46c1XzXAZPVTGuQwBxFG2JfTwRnAFwgcdE2SWdz",
-      "riotHandle": "@stakepile:matrix.org"
+      "riotHandle": "@stakepile:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 99,
       "name": "VisionStake-DOT-1",
       "stash": "13Hp4FEF7z7famvakw8cgioHqDxcnhnyQkvd1jF4dxn7cayG",
       "kusamaStash": "GLxyY9cx27VkZNrf33zHURwLLa58jU8XZeg8HDWkNpX2JXS",
-      "riotHandle": "@visionstake:matrix.org"
+      "riotHandle": "@visionstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 100,
       "name": "🛡 DWELLIR DOT 🛡",
       "stash": "1MrurrNb4VTrRJUXT6fGxHFdmwwscqHZUFkMistMsP8k5Nk",
       "kusamaStash": "DuLr6CeLXezrfumF6EkqLeAx9paMcADYU6zHpSZVB8gvjht",
-      "riotHandle": "@dwellir:matrix.org"
+      "riotHandle": "@dwellir:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 101,
       "name": "ForklessNation ॐ 0",
       "stash": "13ozGG4C5CnB2aQyrdxsf1yf5n4u6252J2Gd9neWk6Zz3psW",
       "kusamaStash": "DroGa6vgtDuLFEhPmTUfLMMeTJQH3h8tCzCDTUTQYcVwmuZ",
-      "riotHandle": "@synapticon:matrix.org"
+      "riotHandle": "@synapticon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 102,
       "name": "postchain_io",
       "stash": "16ZE2MxB25HU8woksoA2xyjfpnQJ1oeuVPpbgceYnimrex9C",
       "kusamaStash": "EHs5p1TR3SpQXvqAUq7pL4qKWRVNmrvtCT4izncvnk6Kh5W",
-      "riotHandle": "@postchain_d:matrix.org"
+      "riotHandle": "@postchain_d:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 103,
       "name": "n-fuse-polkadot-val-1",
       "stash": "1pnNeueeo2QTr72PXirhUUjdPniysKYETik5orGeq1BFAoU",
       "kusamaStash": "DosV2kyxoKTd9GXMDk84XsN78ZXteAdzaQMrk9YofUscuZn",
-      "riotHandle": "@vanthome:matrix.org"
+      "riotHandle": "@vanthome:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 104,
       "name": "Vegas_life_DOT",
       "stash": "149riLdwAVzXg7Cm88RcXhbuFi3zUgwrGsJSSPjC47PRxHQW",
       "kusamaStash": "Dq97kmsJXGTciU1eMXZMAp4D41Y9e7kQ4hmFBfZW7YD4CCf",
       "riotHandle": "@ccris02:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 105,
       "name": "kouti",
       "stash": "13DWNSAdjpHJfknZXzXxUmfkpwgfXFiad5bK2e5bYR35uCYX",
       "kusamaStash": "EAPMuky1KSMoBEY8YkA4dyN7yK3nLczzdodcKRJcXoQ7fCs",
-      "riotHandle": "@kouti:matrix.org"
+      "riotHandle": "@kouti:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 106,
       "name": "luckyve",
       "stash": "1LUckyocmz9YzeQZHVpBvYYRGXb3rnSm2tvfz79h3G3JDgP",
       "kusamaStash": "EDNEfKXHd645DPpBhLZjaEwp4sPhj4STjjS4QrMbFU1FqbZ",
-      "riotHandle": "@luckyve:matrix.org"
+      "riotHandle": "@luckyve:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 107,
       "name": "Khastor-PVN01",
       "stash": "1429tQ2RK8xCwiVYYw7YVUFGX2rbASQN2maMExay7x18neoZ",
       "kusamaStash": "D6NNbc18fTh4WVQtmrTyLRHGv8SKVtjKFY8uV34k5ydBMaV",
-      "riotHandle": "@khastor:matrix.org"
+      "riotHandle": "@khastor:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 108,
       "name": "gtstaking-dot",
       "stash": "16YwUZyLdeAoe4KmhivGwuuJpBH1US4qkUtXK2V83MVXUy6x",
       "kusamaStash": "DxErsWqBducKTqxq7dwXKk2kevAzWEWaYJjwtwzqCu2r3F4",
       "riotHandle": "@gauth8z:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 109,
       "name": "PlusV",
       "stash": "13KoLANqZqUtyfj6hVDzLh3euJZmabuhepT8xG2VrNsF5XjA",
       "kusamaStash": "FfbuQ6wUEfGKxCQpiQcxfMBY5oxKBHiGQVDzAz61Ui57TPY",
-      "riotHandle": "@nagaina:matrix.org"
+      "riotHandle": "@nagaina:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 110,
       "name": "Legiojuve",
       "stash": "15iwUC3GMEFw5QsALmanQbKUVZKFzqQNUsemw8u8RHSFF7Jh",
       "kusamaStash": "Dff4bQQLGsNbF5iAnsjE9bmTd4oxhmnYJXHnhwBLBjC8aBo",
-      "riotHandle": "@legiojuve:matrix.org"
+      "riotHandle": "@legiojuve:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 111,
       "name": "michalis",
       "stash": "129pBPe7kDfuJjdwNHYaT1a8K65fVR5RWjog8xmVYmoQp4zz",
       "kusamaStash": "FZyFBAqs93TenupzDHJzW1pxFLxwwo1EJLvT89jhrV368yb",
-      "riotHandle": "@michalis:web3.foundation"
+      "riotHandle": "@michalis:web3.foundation",
+      "kyc": false
     },
     {
+      "slotId": 112,
       "name": "mmagician-1",
       "stash": "1qWTg2KdN7FD6zUd2Xdv8Fd3WRoTjuBoq4xLxne1p1naBsi",
       "kusamaStash": "HTpGQZf3Ea8b92oxmjRiSdfPPjU1Wy6kVVThZpdvnTCrF7P",
       "riotHandle": "@marcin:web3.foundation",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 113,
       "name": "JUST JONAS/1",
       "stash": "153Fz22gxQP8HM8RbnvEt9XWsXu9nR8jxZC2MbQFmuKhN62f",
       "kusamaStash": "DPdkDRzUV56F5R8fNjZwFx2Uctn173c1UJJXjxQMVMZuCqS",
       "riotHandle": "@amj.stake:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 114,
       "name": "Vires in Numeris",
       "stash": "13bptFJSHHLTBDHupxCRR5ErnLSeHFyeUEU5ufNnBL3JeMpG",
       "kusamaStash": "HZZL1WsAkN8LLd1oFetTzxWGaz3kiVnDNmnC6gkeryBz5xp",
-      "riotHandle": "@viresnumeris:matrix.org"
+      "riotHandle": "@viresnumeris:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 115,
       "name": "Liberty / Murray Rothbard",
       "stash": "13G9QgvXNBhs8CmekiEUFG47E9PPXX2obM7ZbThe6uoD7A7F",
       "kusamaStash": "FUJYqVYujnZNsTKxrHfyhAJv1v8nPodc4LEiSHvBBYzK4Kn",
-      "riotHandle": "@blxxd:matrix.org"
+      "riotHandle": "@blxxd:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 116,
       "name": "Sonder",
       "stash": "15DtxgAQ1XK5ywkx686AdFgLGkFDinoYLx2DyiZBuzUtZZnf",
       "kusamaStash": "CzFKweXiC853a3mrxJFbbmevZpT4i7Yy1iNuwdXZYm4wnqE",
-      "riotHandle": "@sondervalidation:matrix.org"
+      "riotHandle": "@sondervalidation:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 117,
       "name": "Aurora",
       "stash": "124RsxuvWs31iWyUMvDsnoRUgLQfntxeBXnwWJd8eC7EVe1L",
       "kusamaStash": "EK2yYS2xW96AGZaCn21Xcwdp5xzQVAe6VmoSpSYLg7ZvmmV",
-      "riotHandle": "@stakeaurora:matrix.org"
+      "riotHandle": "@stakeaurora:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 118,
       "name": "NewOmegaValidator",
       "stash": "15BMiCvh6cEa7xwCpGmYR4QGsqjZK2FSndjpks6YPT4aC3MK",
       "kusamaStash": "GEx1pz4oGTdNh2mTX8Vrgvfhb2SoA6PoiMqjEfv14nydqot",
       "riotHandle": "@celrisen:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 119,
       "name": "Ethical Validators",
       "stash": "14BeKcfcvJSJjvu9GZ2CA8EQ3XkK9J1HdwDrfz5Sg5ERDnrP",
       "kusamaStash": "DbDAmhLFMhSQkZjnmAYjSktubPiSYKs6ubGtUmt5uC4eHzm",
       "riotHandle": "@evaluators:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 120,
       "name": "☉ lux8_net ☉",
       "stash": "13AxLFBLRACDWzjqEQn3YhHH2iErmyj3kC1HivYiSahkN2Fh",
       "kusamaStash": "DJN9riW92EEyZFHNthLCRmc8BrC3MDGiiVKCpHX8qcizcmV",
-      "riotHandle": "@ama31337:matrix.org"
+      "riotHandle": "@ama31337:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 121,
       "name": "STK CENTER",
       "stash": "17e7dVu8uK6ZSMkS5AoQg8d2EyiXnfjMxq5tXMGWCVUFwhJ",
       "kusamaStash": "HsoF56BFCDgvWtuJ8TcmMgvJ6QTRfWwJauRuUM13qRFfQpp",
-      "riotHandle": "@stk.center:matrix.org"
+      "riotHandle": "@stk.center:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 122,
       "name": "anb_polkadot",
       "stash": "1bYfKv8QUnGm5nSSWpQDPneZkVjU7x3XFyD1bHBMHJJVzqx",
       "kusamaStash": "E4JgAkN3sz4wDG33egGGsCJMu23nzQXrvSLTsFrzFuikbHd",
-      "riotHandle": "@anubidigital:matrix.org"
+      "riotHandle": "@anubidigital:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 123,
       "name": "🍀LuckyFriday-DOT-01🍀",
       "stash": "14AakQ4jAmr2ytcrhfmaiHMpj5F9cR6wK1jRrdfC3N1oTbUz",
       "kusamaStash": "HhnoTHGW76ewz4ZL5Y4F9aPAqD5grq449U6mKfp6i1KuutX",
-      "riotHandle": "@luckyfriday:matrix.org"
+      "riotHandle": "@luckyfriday:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 124,
       "name": "Zizzle-DOT-Validator",
       "stash": "14AngS6QiZvC4AxvWFw7wXwzmctRGL7aWWriococE6rmhKqb",
       "kusamaStash": "GwGCd3XM5qCExnPJT6wyAqygNRZQL9Tqta3txfswnUsEJWr",
-      "riotHandle": "@zizzle:matrix.org"
+      "riotHandle": "@zizzle:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 125,
       "name": "🍁 HIGH/STAKE 🥩 | HEL1-DOT",
       "stash": "12Dw4SzhsxX3fpDiLUYXm9oGbfxcbg1Peq67gc5jkkEo1TKr",
       "kusamaStash": "DbRgw96nMQcFEFZWTLd6LSPNdh8u3NBuUDfAhDmB6UU8cJC",
       "riotHandle": "@highstake:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 126,
       "name": "MC-Polkadot1",
       "stash": "16YGKSNQ2p2SXC2LuGsoBHrm8nKJgnkW9wpvJE6ahBvs6wpe",
       "kusamaStash": "GLdbdQ1E5kM73RN6d8Z1SW7auyneEpp99rxp49ziDaz535B",
-      "riotHandle": "@mc_:matrix.org"
+      "riotHandle": "@mc_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 127,
       "name": "EK-Polkadot1",
       "stash": "154UtMXnexHfUTSvtUZpAfhGi1BejCrRH7YnnGF5faUtaVB5",
       "kusamaStash": "DZzMSwXzbxhnCJePpzRKs1GD3yX25LP91y2Q9kFmPHXQ1vY",
-      "riotHandle": "@plasmajack:matrix.org"
+      "riotHandle": "@plasmajack:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 128,
       "name": "validator_tesla",
       "stash": "15tfUt4iQNjMyhZiJGBf4EpETE2KqtW1nfJwbBT1MvWjvcK9",
       "kusamaStash": "HTyzs9XAxUpHpNe7Kwhp3M5kCJuxFm4AYRCpYjcHdhiVDFE",
-      "riotHandle": "@jan_tsl:matrix.org"
+      "riotHandle": "@jan_tsl:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 129,
       "name": "3080ra-polkadot",
       "stash": "131RTKxEkG6o1HZRRmETxj8ywpSsoF8KgoQp6twnMUf7W4Nu",
       "kusamaStash": "Cg8yN3VucSgk15boaYbFe1mUAybhD8Znh8mnk1PN43SfLZn",
-      "riotHandle": "@3080ra:matrix.org"
+      "riotHandle": "@3080ra:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 130,
       "name": "Cypher Labs",
       "stash": "16Jh21ThTh2tW98NuN2gM7Q3KaYiuJLbxCNbuBkFpwcDkRqx",
       "kusamaStash": "Ht1XzYWEGnLpFwJiRnj6uvtcYqK1fbeL5Us8Z2rkeoCK6Wx",
-      "riotHandle": "@fred3ric:matrix.org"
+      "riotHandle": "@fred3ric:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 131,
       "name": "Sik | crifferent(dot)de",
       "stash": "15wepZh1jWNqxBjsgErm8HmYiE21n79c5krQJeTsYAjHddeM",
       "kusamaStash": "HWyLYmpW68JGJYoVJcot6JQ1CJbtUQeTdxfY1kUTsvGCB1r",
       "riotHandle": "@dev0_sik:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 132,
       "name": "nodamatics-polkadot-polkadot-validator-1-0",
       "stash": "13rfeFLNLU8TfKizGiBLZWaYAwKrAK4JBz5vtU4vK6R427Em",
       "kusamaStash": "GxuEngysAC4a5SZX9w7eTVY4iye8RRxVVXbzfSxXzJ8Nf3Y",
-      "riotHandle": "@andrey.kouznetsov:nodamatics.com"
+      "riotHandle": "@andrey.kouznetsov:nodamatics.com",
+      "kyc": false
     },
     {
+      "slotId": 133,
       "name": "TWOPBL_DA01",
       "stash": "13pZskDR7Pt67NtcChSr4uFRBf9ZS52nQeyrceSykq8MDrMe",
       "kusamaStash": "EiMA69PZWju1jmisAU3ubN4wJQgBexnFXZpWb7aMtftP5rV",
-      "riotHandle": "@generic-chain:matrix.org"
+      "riotHandle": "@generic-chain:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 134,
       "name": "GATOTECH😸DOT_1",
       "stash": "15iA5hpjUecWBbf38Nfegwmtyux25o3LrGaNodfZDxq5nXXE",
       "kusamaStash": "DrRBkx2Qx4sXRGZDXz6d44QCXqV2eJhn8Rq79V88FpSqAr8",
-      "riotHandle": "@gatotech:matrix.org"
+      "riotHandle": "@gatotech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 135,
       "name": "CapitalStaking01",
       "stash": "121NqPL1TNk9pGGdzH19LfeV9W97Qjt3huWUbEncM6yaT18V",
       "kusamaStash": "H1LZZkqyYFv28bjP3HcGM5RdAEoCGFEuA8tHdfLGwwGw73t",
-      "riotHandle": "@capital_staking:matrix.org"
+      "riotHandle": "@capital_staking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 136,
       "name": "turboflakes-1",
       "stash": "12gPFmRqnsDhc9C5DuXyXBFA23io5fSGtKTSAimQtAWgueD2",
       "kusamaStash": "FZsMKYHoQG1dAVhXBMyC7aYFYpASoBrrMYsAn1gJJUAueZX",
       "riotHandle": "@turboflakes:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 137,
       "name": "openbitlab",
       "stash": "13pYWKctR5s8vQuyZt3pxQXue4SRH9coyAS9S9z5HtogAnhs",
       "kusamaStash": "EA9YDzksfSR3RjM5TzKS7bdvEzi7bycXLK15o5g6XTFxFfW",
-      "riotHandle": "@openbitlab_:matrix.org"
+      "riotHandle": "@openbitlab_:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 138,
       "name": "decentraDOT",
       "stash": "15wznkm7fMaJLFaw7B8KrJWkNcWsDziyTKVjrpPhRLMyXsr5",
       "kusamaStash": "GRSWBC1kCuNVp8KTgGyK7Bo3bP7CdLDPwfnx2L5JJLQ41Qj",
-      "riotHandle": "@arthurhoeke:matrix.org"
+      "riotHandle": "@arthurhoeke:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 139,
       "name": "Paramito-DOT1",
       "stash": "13rokpqWneXxGjE8y2YF6H7MtRvqGTqkPR332e3vvMRJet3a",
       "kusamaStash": "FCes7ZDr12Xa3CgfjsZdR2vKRKqNM5fDYbn6TszjgX8KMmd",
-      "riotHandle": "@paramito:matrix.org"
+      "riotHandle": "@paramito:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 140,
       "name": "sensei-bra",
       "stash": "1mx9gKS9DE4H9dvyxCWKMvuKw8bTDu2cgCcFbKNAhYHwyjD",
       "kusamaStash": "DiCVJt4fNZTmsxRSi7J3dDVMTDsCV7k9BG9ray5Yt5WJoMD",
-      "riotHandle": "@jchitty:matrix.org"
+      "riotHandle": "@jchitty:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 141,
       "name": "RadiumBlock-Polkadot",
       "stash": "13GtCixw3EZARj52CVbKLrsAzyc7dmmYhDV6quS5yeVCfnh1",
       "kusamaStash": "EwR2jzx7gZSjxCXbkVZRm39W2fWGJtwXYYftQYdVfcJjtt4",
-      "riotHandle": "@radiumblock:matrix.org"
+      "riotHandle": "@radiumblock:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 142,
       "name": "ICE Stars",
       "stash": "12ZNJzjPBZUh8VV5cuJFkbbwMttFNkH39EhoeYcgGHsJd4MG",
       "kusamaStash": "DyxpaKdwEUP5XCN4Jme11hVRLu87AqKz2q1xBH9xNKzmirx",
-      "riotHandle": "@icecoldnat:matrix.org"
+      "riotHandle": "@icecoldnat:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 143,
       "name": "Amforc 2",
       "stash": "1gBKvQ9vbraAfhxEroBnxoGp9687Hu5wR7NYSwgJeAsw4x8",
       "kusamaStash": "EyQ1wV8jQdKYEWh7FiN2mnkFzAepfq6LfKbWLy7qQkLynGg",
       "riotHandle": "@tugytur:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 144,
       "name": "staking-lab",
       "stash": "127nWP7adKAsXBW135FrBgmt5mxuFA5YpXSrdD6BWp6RUoHs",
       "kusamaStash": "DqJWygp9DwGM6xi31Z11PxZKcg4xNfKQsxWK6NPJmSXBnmF",
-      "riotHandle": "@stakinglab:matrix.org"
+      "riotHandle": "@stakinglab:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 145,
       "name": "p2pstaking",
       "stash": "13S541dQ5NXFCxSBqFUFghkCfUU6LsZUVem7z2tfvsJwWFys",
       "kusamaStash": "G1AX3QgZyjAaNpMgTgnyY9uDgJAzezv84bxHZLgHevmpkVZ",
       "riotHandle": "@1l3c5:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 146,
       "name": "coldstoragecapital10",
       "stash": "1657q1KAuK2aebVc5pSNkuZ2gPMNY6y6vDMLQANdakXnwQ1W",
       "kusamaStash": "DcfRKn9yjeGtLofq2bSfxqJUMd31ia4mqRRwRLcu7ACC389",
-      "riotHandle": "@coldstoragecapital:matrix.org"
+      "riotHandle": "@coldstoragecapital:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 147,
       "name": "🐍snakestake🐍",
       "stash": "12DmPk8ZU1i7R5mUtk5Hmeb6sTyUMpXVuE8HnZ9nZpP1WNTV",
       "kusamaStash": "HG1dCdm3oBZVppZijoCfT3hVygPaEeYLrJRgHt3bU4YQ5yy",
-      "riotHandle": "@snakestake:matrix.org"
+      "riotHandle": "@snakestake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 148,
       "name": "MineForce",
       "stash": "13iacJEHdiTXfxrJ1UPiPAUAv4iXFYdbHbqEDmmdTNhz3h1L",
       "kusamaStash": "J12kKQz1qcCHBg36Txz2k9mNKYERhjKRRSshwUghT11medm",
-      "riotHandle": "@lloyds.tech:matrix.org"
+      "riotHandle": "@lloyds.tech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 149,
       "name": "Hsinchu",
       "stash": "16SDUqoRr6f8DAyKhYWvo9dwFPdJHeFXFr1may1vhomqqPTQ",
       "kusamaStash": "CjU6xRgu5f9utpaCbYHBWZGxZPrpgUPSSXqSQQG5mkH9LKM",
-      "riotHandle": "@hsinchu:matrix.org"
+      "riotHandle": "@hsinchu:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 150,
       "name": "🍀ARISTOPHANES🍀",
       "stash": "128iAScPNNZcoSXQuFp1VkgW376KqvZs61g9Y36MuUX78ZZ6",
       "kusamaStash": "HU6TSsvA84GKrTiyArBHiFDVBSLHNr5Ki3qPV7T8WKyVJaz",
-      "riotHandle": "@pythagoras.c.i:matrix.org"
+      "riotHandle": "@pythagoras.c.i:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 151,
       "name": "Jean-Pierre",
       "stash": "155woeQGxnm2hPnA6LtCYk8Zr2L7FTnWAkfbLi986JU1AADo",
       "kusamaStash": "EYVtSjwsgYiLhwBpoKf8aHc5UfWhnRz2Wcd9gcofNj5Cs21",
-      "riotHandle": "@jeanpierre91:matrix.org"
+      "riotHandle": "@jeanpierre91:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 152,
       "name": "Polkica Dabica",
       "stash": "16WXKsa3jddMq8MTM671LQjUDYHprnrwEpZHyqCrwBTU3Vzk",
       "kusamaStash": "Gtbui8rCwSBKn3v2RdmD2z7TKUCnCChtARmTwQi34ngGZmK",
-      "riotHandle": "@bulrog:matrix.org"
+      "riotHandle": "@bulrog:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 153,
       "name": "Lightning Blocks",
       "stash": "16fmwCAoqJdVtmj7wGEGuFa24WT7x974ZEQsa42x8k9uop1o",
       "kusamaStash": "FMR23WhgV6gW935sjJdvnxT733oaPbBdrkCgurt5AR6JTAj",
-      "riotHandle": "@lightningblocks:matrix.org"
+      "riotHandle": "@lightningblocks:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 154,
       "name": "STAKECRAFT",
       "stash": "13ogHzWQksuwuw4dv6jph1GHGBxjSP8qzwRJzT69dhnhYEv2",
       "kusamaStash": "HKzQetwesWrSoCwidmTFxTDKhvGTtstXBSeWoZYeMtipdVH",
-      "riotHandle": "@n1trog3n:matrix.org"
+      "riotHandle": "@n1trog3n:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 155,
       "name": "⛰ HELIKON ⛰ ISTANBUL",
       "stash": "123kFHVth2udmM79sn3RPQ81HukrQWCxA1vmTWkGHSvkR4k1",
       "kusamaStash": "D2S7Qa6oPYAaJeX7vciJFUCDqBHBkHBfBCGbpm7bog8bBMZ",
       "riotHandle": "@helikon:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 156,
       "name": "🛸 Zooper Corp 🛸",
       "stash": "1557x4U7JTAcso9AHpiVfrEsadABQ2swNWhDeh5WvUn9Zdog",
       "kusamaStash": "GeSU3Yv52v5Bux66tUYRemisbSmWQ8ykPoUt4N7rBy88LxM",
       "riotHandle": "@johnuopini:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 157,
       "name": "snf-dot-validator",
       "stash": "136cgMVW8FeEdLAJmcLMd1CTo3QVZcheyQu1bA3fC9KXTqVe",
       "kusamaStash": "FHrTpbgYUARAmzUiSYqcRjDbCAQ6rqJBbMnKjvNoakNqu2S",
       "riotHandle": "@ihubanov:matrix.infosec-consult.com",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 158,
       "name": "DOZENODES",
       "stash": "167ShbHu769mP5jbtt7AHayJhzEied6s8M5kN5nBSAQewnRz",
       "kusamaStash": "DDhVgn62SE2riWjS6U4AaYtfLNKuFxqTU32EnqAtAuxqM58",
       "riotHandle": "@dozen:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 159,
       "name": "vertex",
       "stash": "13hngqEtbwZnpGJ4vzf8dcgMFB1MxDH4ERaaJBMBMPKur87p",
       "kusamaStash": "GMdKDQYpi6j2px524iP2yGvd9GHDdwuZr3HyBnBFmygeboj",
-      "riotHandle": "@thevertex:matrix.org"
+      "riotHandle": "@thevertex:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 160,
       "name": "STAKEWORLD/01",
       "stash": "14kpNbU4XjEHfYdqp95Gq3NkBWbgFd6J8Yjd2SneWNzvf1Yp",
       "kusamaStash": "CtEni6wrP7Kz2KWus9Y6vQWuhLqJpd9mQFTmTvw8T7FLui8",
       "riotHandle": "@stakeworld:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 161,
       "name": "METASPAN (also try POOL #18)",
       "stash": "16ce9zrmiuAtdi9qv1tuiQ1RC1xR6y6NgnBcRtMoQeAobqpZ",
       "kusamaStash": "HyLisujX7Cr6D7xzb6qadFdedLt8hmArB6ZVGJ6xsCUHqmx",
       "riotHandle": "@metaspan:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 162,
       "name": "Titan Nodes",
       "stash": "1NebF2xZHb4TJJpiqZZ3reeTo8dZov6LZ49qZqcHHbsmHfo",
       "kusamaStash": "DDL4xHwuxi6HFa5wtiikEGQ7yZxTCju3bUXazTxku1Vydrr",
-      "riotHandle": "@titannodes:matrix.org"
+      "riotHandle": "@titannodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 163,
       "name": "SunshineAutosDot",
       "stash": "1EheUmzB58Y26i8hse4EJo9ffG3M5qmhHzrFXJMQLkY9HoX",
       "kusamaStash": "HvCKgQnApvzKJPLc73VSaRhpGFmeQaEyZ4Dbcnj5dJyE6AS",
-      "riotHandle": "@sunshineautosnodes:matrix.org"
+      "riotHandle": "@sunshineautosnodes:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 164,
       "name": "sakura",
       "stash": "1sgm3kyLxWgNWfNMtvnZU7Ammbzhdwbo2TC4hgMPhP91n9M",
       "kusamaStash": "EVTgjzPPHrQwVx97dc7p55hYkVdW6is1mzMr1kacHpkZDTQ",
-      "riotHandle": "@sakuratech:matrix.org"
+      "riotHandle": "@sakuratech:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 165,
       "name": "Mermaid",
       "stash": "126gTJ1q3eJE8fFVjCqkfmz7KKr9g6rZSARXE2yeT1PRpFzj",
       "kusamaStash": "Drb5XkyGvm26ph6d1DE4wxbwqiUCKyVXpcThBUSHE4VxrB7",
-      "riotHandle": "@mermaidonline:matrix.org"
+      "riotHandle": "@mermaidonline:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 166,
       "name": "Aperture Mining 🎂 1",
       "stash": "145SvVXoAwR5ufJynYWDeNXzfyxbf5VkCqkHu3Jt7FSdYBE2",
       "kusamaStash": "FJcnsNkMjY8tgJrDVeq5CKoB1b4Au2xGQjaMv8Ax5QAiV6p",
       "riotHandle": "@aperture-exe:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 167,
       "name": "dot-v1",
       "stash": "152QidDC4QrtMCyRGiQmvrNyjntvMg2XouCSdoPSeqUNTvsq",
       "kusamaStash": "FLiadJNdXvLi8TJ62XzrQVxmZaT8z5hAr1YXQg437r8o4G6",
-      "riotHandle": "@stakeplus:matrix.org"
+      "riotHandle": "@stakeplus:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 168,
       "name": "9Stake",
       "stash": "1x9GAG2hXoMt3i7jL7vTZLpdhNGyjffgQUwe8GU9HhhH62e",
       "kusamaStash": "CyzTh1chfwDa5GuBDfE3BC7e1H7Jnvoz21gf79ckeMJ7xeg",
-      "riotHandle": ["@9stake.9gag:matrix.org" , "@derek___c:matrix.org"]
+      "riotHandle": ["@9stake.9gag:matrix.org", "@derek___c:matrix.org"],
+      "kyc": false
     },
     {
+      "slotId": 169,
       "name": "BestValidator-polkadot1",
       "stash": "1123RekaPHgWaPL5v9qfsikRemeZdYC4tvKXYuLXwhfT3NKy",
       "kusamaStash": "FJgeBDUj4gF2rYxLmxc7QcccEMZQ26xudp4sro3HFMGZMRL",
-      "riotHandle": "@mosonyi:matrix.org"
+      "riotHandle": "@mosonyi:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 170,
       "name": "Texas Blockchain Node 1",
       "stash": "12uYFKgwKxFGMZjkR7AkTRWhFozjJBZpsnuJa6KM8DyfKbdr",
       "kusamaStash": "CwUhDjLKnvtjLM5Caxh4KFEeH5B4LezYM297TxnS7xQw7aB",
-      "riotHandle": "@srivish:matrix.org"
+      "riotHandle": "@srivish:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 171,
       "name": "Watermelon",
       "stash": "12pJGRmrWoZohZVFnGK2hhoMwzCVkjmEjwv3C5wxdnbCAiEk",
       "kusamaStash": "FPc6HXzVyCbsarcyLEN6UnHbhWxdUputwEe5saQxmMUj63X",
-      "riotHandle": "@watermelonnode:matrix.org"
+      "riotHandle": "@watermelonnode:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 172,
       "name": "mathcrypto-dot-0",
       "stash": "1bjtWMjjq4GLDQhaWT9Y2wDcWqcQ83gYbfdvECQF5WDA23A",
       "kusamaStash": "EARQCUK4Y3oN3LCuyjriBxPesNAuQWa7ifjsfNSU6srpFAq",
       "riotHandle": "@mathcrypto:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 173,
       "name": "infsysgroup",
       "stash": "13YJ7PrjwAhKHP9m99APDSuvLwWKSQSmKABfJY3H2Cepk2CA",
       "kusamaStash": "J6ixMhTj9UmgZtNiWVGs1SdGm9HXSj7z2Emjc9syMgGdN5X",
-      "riotHandle": "@ignatev:matrix.org"
+      "riotHandle": "@ignatev:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 174,
       "name": "COSMOTRON",
       "stash": "16KjnbCmBXqT3R956sHak7THsgQZ9Ek8ibnG1sFyCNtfJ8y",
       "kusamaStash": "EVhWhw6w6i5C9SV3FbHdM1rroTxsM5UzxEKMyXCwnct2EnH",
       "riotHandle": "@cosmotronv:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 175,
       "name": "VALIDATRIUM",
       "stash": "15SfLgBPmtLAuqTdvga72k8g3rPTzfidgssXV4n4DvfB8xgr",
       "kusamaStash": "GNxLBL5TiXry4mWZmuDqmqj5JByWQkLr4sNP1RhF6Mo1HQ8",
       "riotHandle": "@supermyzuk:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 176,
       "name": "bLdn0d3",
       "stash": "12bLdVAgWiKHgFHtAaQstasMUWVq35oG9iwHCwsKoFFNoNrk",
       "kusamaStash": "Hf8C626KBAjitMV7w8AhQWDCiPgUU47htEwbomq5mDMKeyL",
       "riotHandle": "@bld759:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 177,
       "name": "Chris Staking/p1",
       "stash": "16hUkBK3h94uh7682gk7HeTYvPmSa4D1Y2w4KUZh1u1cP5J",
       "kusamaStash": "EAqxvPZ3nxyfum6d8DFBeGuykQayJHtE6DyCcHMyd6o57WZ",
-      "riotHandle": "@clang:matrix.org"
+      "riotHandle": "@clang:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 178,
       "name": "Exotic Stake",
       "stash": "13VS9jM2pkKNwd8LFpQNNRPBKUonU9jzGZ5fTEZiuB4nYF6Y",
       "kusamaStash": "JMkSXXco4mxTRXNyRgYqeNpRZDXZ3i1qdKMP5FoMphCE6fq",
-      "riotHandle": "@exoticstake:matrix.org"
+      "riotHandle": "@exoticstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 179,
       "name": "DotSkull",
       "stash": "13NbzR1jse1FgB699sTDSfHUB4bqec1xKt7my7cXiL8oGd4w",
       "kusamaStash": "EUYfsTNCCVJbrq7YjT4xbxWB8GX1j7nRZiuziQVj9mjFSdP",
-      "riotHandle": "@dotskull:matrix.org"
+      "riotHandle": "@dotskull:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 180,
       "name": "UT Fintech Lab",
       "stash": "1uvodkTYJDYbdBEX8qVuW79fo4g9KQyE3dd8b6x3ZbR4ept",
       "kusamaStash": "HD3uoRSHiGftXfWe31Gp44yezjuaqfRX5izjg3k2wSYoCTd",
       "riotHandle": "@ufintechlab:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 181,
       "name": "Munich | validierung_cc 🇩🇪",
       "stash": "15x643ScnbVQM3zGcyRw3qVtaCoddmAfDv5LZVfU8fNxkVaR",
       "kusamaStash": "JHamburgTPv9fRKwTPeBEjyVHmbQK2ayRBpBujb4rx2sHzJ",
       "riotHandle": ["@kev.funke:matrix.org", "@bkzland:matrix.org"],
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 182,
       "name": "web3:stakenode",
       "stash": "14MKRNHaJY2yC84SkW7oXhnzVdV3obogoH5s8H4AkzxaFmAS",
       "kusamaStash": "FvdwMNP57nRWEsNZZsrHWKqnbmduy4jBAC8MeLmgi9Yp8sA",
       "riotHandle": "@stakenode:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 183,
       "name": "bigTuna",
       "stash": "1AvwyrRcECEWUnkRoqfcyT2oA11uBT66aS4p127Mbs4ocjq",
       "kusamaStash": "FntXNA6GesCTLJQZUt1LjyUCxkTbhCYny4Y6UdT8et1aqNt",
-      "riotHandle": "@tunabig:matrix.org"
+      "riotHandle": "@tunabig:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 184,
       "name": "Mass Stake",
       "stash": "13VZKQk1dA8W4Z785mU2UKfsfwXKNknoYdXw6MQNQ8KMuniY",
       "kusamaStash": "F4sqPppPjsxNfv3tqE5E8CixuouV83qvWeCKigyKqWLUXuQ",
-      "riotHandle": "@embiei:matrix.org"
+      "riotHandle": "@embiei:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 185,
       "name": "Rekt Street Capital",
       "stash": "15R8n9VVEFEGnAb84zZxYATAVHV6Vw6CJHmz7gsWVdKZrsea",
       "kusamaStash": "FkrektytDeepNHKZMMiPYZsrmgrVum9cqZmE4fsz4cotKs9",
-      "riotHandle": "@rektstreet:matrix.org"
+      "riotHandle": "@rektstreet:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 186,
       "name": "ERN VENTURES",
       "stash": "16euDe2owvJq7LkwSujGxAFezCWopCKPENxwc2EKdzYTRBae",
       "kusamaStash": "FHsDBsDmxzsANzvDrPBCzxyRAAYuTHCoe5d6vzi2qEdTBKk",
-      "riotHandle": "@ernventures:matrix.org"
+      "riotHandle": "@ernventures:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 187,
       "name": "big-wave-dot-01",
       "stash": "12eLumQrMcs7GnRdM3jQmhZG6hZMC61VYwi281CzPPkwAQch",
       "kusamaStash": "CrTPV874i4VNTjkCfQbGpPT338dhyu27w6poWrKuZZpEz17",
-      "riotHandle": "@big-wave:matrix.org"
+      "riotHandle": "@big-wave:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 188,
       "name": "Green Cloud",
       "stash": "1HtWJy6zTTc6Y1hyRTVpM6MDCpiWknsjDssUPC3FTKjfAGs",
       "kusamaStash": "DPb2z99bbieLXWADo1dsLTijTc84vktx5nZmu79NztbC3NS",
-      "riotHandle": "@green-cloud:matrix.org"
+      "riotHandle": "@green-cloud:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 189,
       "name": "kuzo",
       "stash": "15PPJX7PvSbN7k6FSVZ5wnjWiMcf3swyRu4rzBZMnuhP7Koj",
       "kusamaStash": "EAcDiMkyNsmiRY539ELBzSmjVwpfrcmPXEJLRME6DTiN4GF",
-      "riotHandle": "@guzo:matrix.org"
+      "riotHandle": "@guzo:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 190,
       "name": "prostakers-com-01",
       "stash": "12R2eXcE2QhMa9BkMsWktt9wmoxbgiQBDG9YUM1p94r2F5UD",
       "kusamaStash": "JLcdsEGtVtR22RuRPDa2tCMwBCox1FnyhJS8UWwSge1q8L6",
       "riotHandle": "@prostakers.com:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 191,
       "name": "LEGEND",
       "stash": "14zfiH2sMH955cG2yKUQbHSP3oQ8W4Ai9p9wSSZunvQ4TU4k",
       "kusamaStash": "GHewg8AxLL7JpRYDoqEyTk5bhGndhMvsDWo68St7D9YDH9Z",
-      "riotHandle": "@legend7341216:matrix.org"
+      "riotHandle": "@legend7341216:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 192,
       "name": "Powerstake-p1",
       "stash": "15Xx6ToS88iUagZ6BNJsEMKDbo4V7RcjdJk1FGfdxLtgqVs4",
       "kusamaStash": "HnZafcsErZXmc6gUupBDzNVayTQbraN5fvzoC7XYKev8f5q",
-      "riotHandle": "@powerstake:matrix.org"
+      "riotHandle": "@powerstake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 193,
       "name": "😻 Stake Kat 😻",
       "stash": "155LwjGpJH3xYJwPBr6aapk2WCCAezVftvSMrqeJA6eE7v2d",
       "kusamaStash": "GefTiMd4roQrRkJzurdLdGsoAUkmMkiGoYd6Cvu5oqCgamX",
       "riotHandle": "@fmonza:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 194,
       "name": "punkrock",
       "stash": "153RzmMmQ2ueHgD71nRcfcs96VKhFRPYkW2h1qw18Bn1Jkrv",
       "kusamaStash": "J75Bj4JkQ1oZ5Y2UCtLBq8FFHDdnrfTQgDGErvk9kyS1wMn",
       "riotHandle": "@punkrock:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 195,
       "name": "STKD",
       "stash": "12pdN2XsNmG2yPAv5QCkq7YYUg1MM3prvGMgusH7S6FnDHAx",
       "kusamaStash": "Fq4YmiAq76DntjMKKjMiL98MYszoApUa9idSErvyzfdGoqG",
-      "riotHandle": "@frazzled:matrix.org"
+      "riotHandle": "@frazzled:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 196,
       "name": "Steak ♨ Noodles / 1",
       "stash": "12jZDB1QiwffAdADz7r2tBALX3rAWQjqvE3PRuNmQXsd9pnw",
       "kusamaStash": "Cz4uW9PwEgqFwyjRBiSWY4AzXzuxc1dWjoLDd3QieVaZoD4",
       "riotHandle": "@steak_and_noodles:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 197,
       "name": "enby-collective-1",
       "stash": "15TJJXDwEp2fuJb9b4LwsCuSTVhRdESmY193cGGLfZtSSiyG",
       "kusamaStash": "GMCdBvMap5gNLshE9cWWJyTCsBFr3Tp7cUHXisUG16C95kg",
       "riotHandle": "@achim:parity.io",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 198,
       "name": "Vixello",
       "stash": "1qjNXPh99ExYXmuqHgmvfmmwjjka1M21jaVDPddZtKZhzKH",
       "kusamaStash": "EiiSBrZ9kPJhPwf114LF6DyrHCLSKucFTS2TPpSH7zWkTTG",
       "riotHandle": "@vixello:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 199,
       "name": "Xalamus",
       "stash": "16XxKGBRWSCQZwrpgcnzE1HqcYC3xJBcSJrM1pRazfmuSrio",
       "kusamaStash": "FfbGaF1B6hNMPNKcjgyciU2RqbAgF8UmW1dAxTi667odgR5",
-      "riotHandle": "@xalamus:matrix.org"
+      "riotHandle": "@xalamus:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 200,
       "name": "Chain service",
       "stash": "18zLxNjoSpuQDFz9eSf3cLoZrPXM1dJrkwfYq6sWqLSfFD3",
       "kusamaStash": "Gv7aohxceo5XqeDZzJzxR5fxGaZwQUzSpmRzNXSLFvJdvbw",
-      "riotHandle": "@chainservice:matrix.org"
+      "riotHandle": "@chainservice:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 201,
       "name": "Block Bridge",
       "stash": "15VAuiX2YiK9eXWf3xGBjbBNTzzRXsab2DGoi4rNgCfRFWM8",
       "kusamaStash": "GqjrCgD6GmZFRSYBr6w1BSuXXbqFgaceDAAezDxKF5XdNQb",
-      "riotHandle": "@blockbridge:matrix.org"
+      "riotHandle": "@blockbridge:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 202,
       "name": "spaceman116",
       "stash": "13mdEPcL8qgJuMkgpqeP4dvMgyRJSSNGSB5Px6G1eZHYJ2SB",
       "kusamaStash": "GbmW3q2Hv5UaiRreQuBtevXb8DHdvsRFkBGXe2Xz1Y9FM8a",
-      "riotHandle": "@spaceman116:matrix.org"
+      "riotHandle": "@spaceman116:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 203,
       "name": "NRD Labs",
       "stash": "1jZGoE9teJBzaQxNpYgdJnTJ3a8rUsy7Ws6X3JcwHWTrsgf",
       "kusamaStash": "ESCob7AAYWVdifL9jaYEokbZ9rfRrRtGUQ22EK1N77Nc67c",
-      "riotHandle": "@nrdlabs:matrix.org"
+      "riotHandle": "@nrdlabs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 204,
       "name": "spicytacojalapeno",
       "stash": "159ig1wCFX7zinhLyrkep45oqisLCGNMUTCuZJWaMqRdNLLv",
       "kusamaStash": "G2f6aFnPDGCrr4BivxuUSQWEd6W856mAPwiSWMJ4f2xuWVp",
-      "riotHandle": "@spicytaco:matrix.org"
+      "riotHandle": "@spicytaco:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 205,
       "name": "LEPRECHAUN",
       "stash": "12cWBTYcw1v1idFbhZWHz9KeDz7YW2C11dTcLuLvkLLYBhq1",
       "kusamaStash": "EiVu6mJZWpf4V2GQq1SZ9GQdJfy2SZB7J8y5tcL2Qr1fBoM",
-      "riotHandle": "@polkaleprechaun:matrix.org"
+      "riotHandle": "@polkaleprechaun:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 206,
       "name": "Alzymologist-01",
       "stash": "123rZfdp1R6pBAN8Uft7NtsnSNLHvLgrBSkvLXtXcXtbP2Z9",
       "kusamaStash": "EAp3SeY72kfoCUV9SRbmZyiWVEhoQevwLASo7HmiTxCVKuv",
-      "riotHandle": "@alexander_slesarev:matrix.zymologia.fi"
+      "riotHandle": "@alexander_slesarev:matrix.zymologia.fi",
+      "kyc": false
     },
     {
+      "slotId": 207,
       "name": "SteakChef-p1",
       "stash": "13uvDxdd6LUNp1WWzM3xbch7q1DFfAaqRaQE5bo5QG7RGqt",
       "kusamaStash": "HAGEDeWTMag1By2N27w53C5xfK6mzbNPi9L7RtCamEzThHH",
-      "riotHandle": "@stake-chef:matrix.org"
+      "riotHandle": "@stake-chef:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 208,
       "name": "SPBDrink",
       "stash": "15x1gKGjYQQi42D4ER8Wvn4gGDQn8FBTqU9faBum27CCsLQY",
       "kusamaStash": "E7yeQXKWCg9XxjVMZULJNrFBgzSBLRpHoPGcE9Z1M7jC5c8",
       "riotHandle": "@spbdrink:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 209,
       "name": "blockseeker_io",
       "stash": "131Qzz7SvHUn7zdDAt2jFZmzVsP2KkoiDWLZa9N7FivGTXpB",
       "kusamaStash": "HPuireorhWdSCQg5dG1zeGk7XCuAfkb21BtDyLqRuN62k67",
-      "riotHandle": "@blockseeker.io:matrix.org"
+      "riotHandle": "@blockseeker.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 210,
       "name": "Peiron",
       "stash": "12b843A8c1w4CnHNkLJxtAyMe6AjiiKvZqJ7R6kD66phq4eu",
       "kusamaStash": "EMrTktHLYSHAqpVH3f2KMMoLkZPMWjeQAZLpZTJ6KgNcXVr",
-      "riotHandle": "@peiron:matrix.org"
+      "riotHandle": "@peiron:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 211,
       "name": "MarketAcross-BB",
       "stash": "14jHouxT1VbhBDw93VW8Z89p139Qgu7ECHz3zxM2CpQEDJDB",
       "kusamaStash": "EzAUyKjTG4BooK598kPGAWJzXqBAzfL77KYYfdqxPzW1G4f",
-      "riotHandle": "@marketacross_bb:matrix.org"
+      "riotHandle": "@marketacross_bb:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 212,
       "name": "MerkleTribe Ξ Bayaka",
       "stash": "1cJNyZCPxpf1UPPt8ckHsiN8N77ykMK9kmamrFY2rE6d77F",
       "kusamaStash": "HtLiQjoJrg2hJp4xc75ruiG8EMmpJkkXmRZztomZyQE4qZt",
-      "riotHandle": "@merkletribe:matrix.org"
+      "riotHandle": "@merkletribe:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 213,
       "name": "Bueno Validatoro p1",
       "stash": "16JwE96t9MMvWQHuyHntqVyo6Ks97XCK1kHvWumGNLGVJg5p",
       "kusamaStash": "16JwE96t9MMvWQHuyHntqVyo6Ks97XCK1kHvWumGNLGVJg5p",
-      "riotHandle": "@buenovalid:matrix.org"
+      "riotHandle": "@buenovalid:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 214,
       "name": "SafeStake_IO_DOT1",
       "stash": "13pBLqciqvBMZpZT2ZkavANK66PxyG1xZ72bBo849c5NDHgh",
       "kusamaStash": "HnqvLipy4zndzJcJWAVJDpDWNMR6ygTVDRym5BeapXHLS2K",
-      "riotHandle": "@safestake:matrix.org"
+      "riotHandle": "@safestake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 215,
       "name": "Krawiec",
       "stash": "16SE3e2wrVNUZmEjWcioAEox2PXzkxeTvwCW3pTTWvmDQZJi",
       "kusamaStash": "CzB1XBwkko3Az7DNZDPigZ1bjzLxELAGnLBnFGRdQ4PXTqZ",
-      "riotHandle": "@krawiec.:matrix.org"
+      "riotHandle": "@krawiec.:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 216,
       "name": "stakeHulk",
       "stash": "15uCAG6qK9qdx3EG3kyb5TFn83PgFUSQEioUgA9GLTjMFfq",
       "kusamaStash": "J3uneckXiaJvUiBnGf6Dp3bBgP2Bk615vGcyyXNh3NsTNBm",
-      "riotHandle": "@stakehulk:matrix.org"
+      "riotHandle": "@stakehulk:matrix.org",
+      "kyc": false
     },
     {
-      "name": "\uD83C\uDF0CNOVASAMA\uD83C\uDF0C/NASH",
+      "slotId": 217,
+      "name": "🌌NOVASAMA🌌/NASH",
       "stash": "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
       "kusamaStash": "127zarPDhVzmCXVQ7Kfr1yyaa9wsMuJ74GJW9Q7ezHfQEgh6",
-      "riotHandle": "@solocrack:matrix.org"
+      "riotHandle": "@solocrack:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 218,
       "name": "DARK_POLKADOT",
       "stash": "14BnTrXDZH9diqkzKNqGCf4BXG8oJRBdiKFfsRem8LYDRQy7",
       "kusamaStash": "JCHVzJjBWS1ZxkTZJN1jifYrDcspepCU2YCW23XhtVQnYE7",
-      "riotHandle": "@darkless2001:matrix.org"
+      "riotHandle": "@darkless2001:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 219,
       "name": "fortunenodes",
       "stash": "12ZhwG3obkAYwwuHSzB5Cy5BPmWxqoK2XsPCuqHZgB9XwRFU",
       "kusamaStash": "GUw3gm93T85i9Syb4hA3NotNMFgCB56p7osxi3hnoqforMj",
-      "riotHandle": "@gislemon:matrix.org"
+      "riotHandle": "@gislemon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 220,
       "name": "utsa",
       "stash": "15wnPRex2QwgWNCMRVSqgqp2syDn8Gf6LPGGabRhA8zoohpt",
       "kusamaStash": "D5khA3qGvd8SDXepSrCGmYRWbNUzdJpjEyg6m1mFT7VtHpw",
-      "riotHandle": "@lesnik_utsa:matrix.org"
+      "riotHandle": "@lesnik_utsa:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 221,
       "name": "VLADIMIRPRO",
       "stash": "129QVy2hCC4fdLsjK7d6vt6DrT6Mj8A3M4nr8oL1jEXcdVVm",
       "kusamaStash": "HUE5nUANxvCRW7SoLAHcKdB2PLoUpUVyuSdviHrKKQAV5EC",
-      "riotHandle": "@gratevladimir:matrix.org"
+      "riotHandle": "@gratevladimir:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 222,
       "name": "ULTRA-DOT-1",
       "stash": "13xN9Mw1Xif5VTd9RdVEjaYjPsZAZeSKbukuDVHzxAjGjJ1Q",
       "kusamaStash": "GVGsDZBoccL1YFnJS8RCpYE6aT2sXZkKtfSTJhkXD2MBrmJ",
-      "riotHandle": "@ultranode:matrix.org"
+      "riotHandle": "@ultranode:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 223,
       "name": "BlockCtrl",
       "stash": "13b2BHxiamr5QCzLHqPUgKfTczRZvH47eQ9WqSQSP7UyMZU5",
       "kusamaStash": "FALhH3XMMbXiKoG6u9XS8CJuxiA2eKA2HFn4oh3JpfwvBNF",
-      "riotHandle": "@alberto_bc:matrix.org"
+      "riotHandle": "@alberto_bc:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 224,
       "name": "YAO Gmbh",
       "stash": "133JUUgdpD4DGtPgZaUQZmnW3VYu1QHt2DYTyy6GWC7HMQCn",
       "kusamaStash": "HxVdrC3UWVvjSvcH93ntr2J7PRJgM43Duw8nYaGyKwa2VkA",
-      "riotHandle": "@lukayao:matrix.org"
+      "riotHandle": "@lukayao:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 225,
       "name": "ksmoon",
       "stash": "1mxRu46U8LtWFrsBCpumjaFnBmGoSt6SgonskNR2m1A9nCM",
       "kusamaStash": "Hpf7KTh2LmZiGQe3qaahVsMN8LSak1UFMgSJtUdDHpSiqjU",
-      "riotHandle": "@ksmoon:matrix.org"
+      "riotHandle": "@ksmoon:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 226,
       "name": "anvel",
       "stash": "12pHJra8Wm8TKmUhVjDJgcWbYQm5q7BPtzm7mmZGaJHBcf7u",
       "kusamaStash": "EPbpqewHLsudtHdJnyMSR3SqP3fwUSSGssP18qsW1UABaFr",
-      "riotHandle": "@anvel:matrix.org"
+      "riotHandle": "@anvel:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 227,
       "name": "Magic Tab",
       "stash": "12bwaiu2AN7944nT1n3VX9UR2F16PuVDbtGC61Wk5DLzQJsc",
       "kusamaStash": "G29SmTWUhXHMQrTBdC8hTMXu5G6YKwt4AsefNqFH8NMi5eq",
-      "riotHandle": "@ysnaynn:matrix.org"
+      "riotHandle": "@ysnaynn:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 228,
       "name": "Brilliantine",
       "stash": "15ybn9sXnosquc4v8G1GUQrgcWD6BU5nZGpERMEyCqJygMPV",
       "kusamaStash": "J4KJhPbV5QSFtDmjk13LUtakSBESge4LE3EBZoLBEfkAwaA",
-      "riotHandle": "@brilliantine:matrix.org"
+      "riotHandle": "@brilliantine:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 229,
       "name": "Statutory",
       "stash": "15kXizCQG5qCphnqsZvLax4zG8D9GfKdixsLbPXtP52BBU94",
       "kusamaStash": "EcxGijR4Er3sfxVHtXnJsG4YjfMEZ6nG3GK5RgxGCnhb3fy",
-      "riotHandle": "@statutoryio:matrix.org"
+      "riotHandle": "@statutoryio:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 230,
       "name": "Blockchain side",
       "stash": "12eVBx2xjVFzHyyGVHCqEQMp2yntKiSzE2JuGYM1kQAjVKzu",
       "kusamaStash": "G2Q8mTftjxrrVzkUTuRh1mSemdw7vQSFdxx55gneNc9ptem",
-      "riotHandle": "@sideblockchain:matrix.org"
+      "riotHandle": "@sideblockchain:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 231,
       "name": "GameTheory-01",
       "stash": "13Srw7dVtGJnZrV3o6RCAJ97MaGbSKShQQiSYjbGp4Jvu4Cs",
       "kusamaStash": "DY3hczPcJjHXScXkKwJZ7vgqTE4bZaCUa56XsAQH8gDzB7x",
       "riotHandle": "@game.theory:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 232,
       "name": "helixstreet",
       "stash": "16WzVw5JDCXLiA3t5D4LL15S2sqSBtCsjVNXkwLCVxGdeQGj",
       "kusamaStash": "J6K1vA6ynGo2GrotGpP5ocHKr82JFTv7NUnzJcoRfTcCn8T",
       "riotHandle": "@helixstreet.io:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 233,
       "name": "Cryptography",
       "stash": "14p3QPfNeBwTiSjEVCjhTDCftyyzqoe7aW6SLD7jpTLXizri",
       "kusamaStash": "DB9bVarUeUkbdACKaBC8zHeSfLQCKdwgJmKCvpcqvC1C6Zw",
-      "riotHandle": "@cryptographyvalidator:matrix.org"
+      "riotHandle": "@cryptographyvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 234,
       "name": "FUTURE",
       "stash": "12eKXDMUnGVp2ScEKXbFNxbgktL7DEchLKTFrayspgqwDraq",
       "kusamaStash": "JEfXUjhjjnb2RZmuthXjDGAf34T1SndetNB5gN1uJZ1372C",
-      "riotHandle": "@1futu:matrix.org"
+      "riotHandle": "@1futu:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 235,
       "name": "Diamond",
       "stash": "15N2nvyikmU96F5wE919Gc6YLAKGtL6NoQ5ixKLeLp4T4LBV",
       "kusamaStash": "FergEor1g4fw7a81PqXjrQLTWCcXJcFRHJwzVdxrZf9tuQB",
-      "riotHandle": "@diamondvalidator:matrix.org"
+      "riotHandle": "@diamondvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 236,
       "name": "Blockchain Merlin",
       "stash": "1To8mJLPm9spZdQF1ziHMoc7ZCDHYUeCjDzQfN4j2qY6XRe",
       "kusamaStash": "DVQzUfux1dT8CD1yrTJRsb2E9dJgy9h1wKknHhSTW44DXob",
-      "riotHandle": "@merlinvvs:matrix.org"
+      "riotHandle": "@merlinvvs:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 237,
       "name": "Rotko Networks - dot01 Validator",
       "stash": "1ArdZJtNUrZsfidfn1t69xHaSWwzf6PQNdLEUpcnVmbkZc5",
       "kusamaStash": "DKKax6uZkiNPfd2ATd8cJhyi3c1KZD24VDdoWG9CfTmwgSp",
       "riotHandle": "@hitchhooker:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 238,
       "name": "havik-polkadot",
       "stash": "13pk9j8duuvckyNsXUch5YZFYXN82oCZZVLeKDzgJDFGZY3A",
       "kusamsStash": "FQ4fiDSgVg556BoLYNjqM66qVei9ATbwNSuYbHHDvSF8Hb3",
-      "riotHandle": "@havik:matrix.org"
+      "riotHandle": "@havik:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 239,
       "name": "Activator | Serbia",
       "stash": "12WNzfWXzogo8N27yNuE9T1xXC2VyJYmTqRDuePp2CNJLgPk",
       "kusamaStash": "E5hWebLmPSFSUq3nSfGuFYopAK65fooqiXV91gQwuZGuMad",
-      "riotHandle": "@activatornode:matrix.org"
+      "riotHandle": "@activatornode:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 240,
       "name": "INFRASTRUCTURE CORPORATION",
       "stash": "16fbkDCMrAo1uyC52NyA8Y2dETnYVpCofSoj3QEE2WUNnkLk",
       "kusamaStash": "JKupaoCtkRzMjCDQJbVMbG1jmEr8ebtoRG7cmxWkc8vM2uZ",
       "riotHandle": "@yayoi-v:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 241,
       "name": "gurustaking_gplk_01",
       "stash": "138tCNoHg9QbhjqanRS7R8ZC8547A6CdaSmrCtJCRLpjQk6r",
       "kusamaStash": "F5j1j9TJ7xWePJmYh64Bf2b97pmer3mX1BsonCUpx3CJZpu",
       "riotHandle": "@gurustaking:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 242,
       "name": "LavenderFive Nodes",
       "stash": "16cDjCXSYGRDpEett39taTgMAN7LKnyaafa5MgfbUmpsERW8",
       "kusamaStash": "JBYFBcFJrAg8MTph6uwLGDCTLPvSAEcxYgLb3xCQV1qo7H4",
       "riotHandle": "@reversesigh:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 243,
       "name": "🏹 Robinhood",
       "stash": "14Bf4m5CTNrtGcgCAp6xsXMgA9pPeoiVT54g3C2qY1zNvgsR",
       "kusamaStash": "GJWFwL8bxZszS5nJNWCV6vC5nBERLgscKSeNF3U9ZcQxL12",
-      "riotHandle": "@robin.hood:matrix.org"
+      "riotHandle": "@robin.hood:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 244,
       "name": "APPLEPIE-DOT",
       "stash": "12YUDdiZCHE47WqR6etGD4gfdpSUhrRFvASrVhtc1RcbLva8",
       "kusamaStash": "E7njcoMxryWRdeLuieJxsDWvnj4pDgJJ3Z7j5BCw8oZuMVX",
-      "riotHandle": "@kamelstaking:matrix.org"
+      "riotHandle": "@kamelstaking:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 245,
       "name": "Rhombus",
       "stash": "13r8ZXgYi7KZPhAVXjpznzbmyXwWBegebtr5gJwUnvNYXwp",
       "kusamaStash": "EDKXrYEqmAnMZnZzzRSby67Fgf5yFUSpbmQMN1rJHPTWbVV",
-      "riotHandle": "@rhombusvalidator:matrix.org"
+      "riotHandle": "@rhombusvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 246,
       "name": "MOON LAMBOS DOT COUNTACH",
       "stash": "1311nP52HPRLCvSS4EXgWfqRfXnjexbr7t82aedpWpGCPnxV",
       "kusamaStash": "FLamQXqxns6tVsDTVpLoqqynq7nbpHvJaHMzVwX6Yb3eThW",
       "riotHandle": "@moonlambos:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 247,
       "name": "Brightlystake",
       "stash": "1CUBGfKnpHCW1AZbdJGGj1dihn4QNZ623THYs59r6yuPEMq",
       "kusamaStash": "DPyccDy3aecJqo2DTpFUFpnQAeaSEj9hbrpEzUSJnScAXpR",
       "riotHandle": "@brightlystake:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 248,
       "name": "landeros | StakeUp",
       "stash": "13uifUNALuwqiHZADQb2hrpwnL8kmawjqykx4yN661Tv7mR",
       "kusamaStash": "H6q7Z9t3vuezyoicdKPHTYxVzrCU3JPKJWk3wGyxuEFaB9m",
-      "riotHandle": "@landeros:matrix.org"
+      "riotHandle": "@landeros:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 249,
       "name": "Oracle",
       "stash": "16ZkdRYne6geWLkhaMgraDkXXiKHwSSQkCtQ2pPJPtoroURn",
       "kusamaStash": "DczAw1iwYjCftH3NJC1Cp3oXLxUbLSKnb4d2UrXNVLMKrgo",
-      "riotHandle": "@almario:matrix.org"
+      "riotHandle": "@almario:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 250,
       "name": "F5",
       "stash": "14iv55u5DvgqKSSTvcRjP3ySEeUcQTjvGY3zFdA9JeHXqyb3",
       "kusamaStash": "GJEb4yszWSHdZFPjgBn8rWHXcmCWpzxeRAFUzSkEMUWQLj8",
-      "riotHandle": "@kusama2233:matrix.org"
+      "riotHandle": "@kusama2233:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 251,
       "name": "MIDAS",
       "stash": "131PZkz6A4fCFsXnefPnQwn5To6gvJFoit2boavU6ryUQoNE",
       "kusamaStash": "EyJgtqqbVsxArS7zuDq8rGTCA7m5WAqxv32msopPfWxwwpA",
-      "riotHandle": "@midas89:matrix.org"
+      "riotHandle": "@midas89:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 252,
       "name": "🧱 Seitan Block 🧱",
       "stash": "1zkLKr5TdWi7q2CCXRychcG36knyc3cwg6UebcYbkDzdv2p",
       "kusamaStash": "Da4rJvtEDGARwq81bC2NW97L53P5yJfKZCjsxu9XTQyCVBm",
-      "riotHandle": "@seitanblock:matrix.org"
+      "riotHandle": "@seitanblock:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 253,
       "name": "validorange-dot1",
       "stash": "1D51dxpuGv1mWxstx7ERWyEWieLHSeQ8NBVX7VxkxT5PuKg",
       "kusamaStash": "J47U9wGuwzccFPoz8bnMTKJt7WGpPp8ZNgvtXFDL9PHwpCt",
-      "riotHandle": "@validorange:matrix.org"
+      "riotHandle": "@validorange:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 254,
       "name": "👾Space-Invader👾",
       "stash": "15u9KTyZzjVQJaCVmAPhFNjwyyS7aHjb6m5Exa22fRXQpTp6",
       "kusamaStash": "FDL99LDYERjevxPnXBjNGHZv13FxCGHrqh2N5zWQXx1finf",
-      "riotHandle": "@space_invader:matrix.org"
+      "riotHandle": "@space_invader:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 255,
       "name": "GRABBITY ✨🐇",
       "stash": "14fJ6M6n36La68RVZaWrpkki1DfWuLp1L7hALxeCYeNSu7vG",
       "kusamaStash": "DShgED7MWc9UrfcoofsFAcK6YJqRHpMYcfDk5odpM2C34FF",
-      "riotHandle": "@grabbity:matrix.org"
+      "riotHandle": "@grabbity:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 256,
       "name": "stakemagnet-server-splk|XA",
       "stash": "13Emjax1tBfQMEKisppTMMe7jMbqpmCH1jRpTXudLocaevND",
       "kusamaStash": "HKk5gnHuuePbKq6UbMn7sV3UxsifyZXyhYQqyrL8RPRBdq8",
       "riotHandle": "@stakemagnet:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 257,
       "name": "👋 79anvi 🍀",
       "stash": "167Pbuy2HvbHshqc7Xtk4cweCXyyZoJLttAsddDuH3tN7Fco",
       "kusamaStash": "GHuTRo2jNiXZyc87dU9jRF5iASx1J9G4rgZLPgxxFpj6jD3",
       "riotHandle": "@79anvi:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 258,
       "name": "dotstake_io",
       "stash": "13tvM5A12b9yQFs9TJWH1Bc9iiN7d7jZGnqJXdF85ovHruh6",
       "kusamaStash": "EaNqkv87hVL8vvwBcTxeCkECkzRuyFLVtSmrVCDhfj4dNmf",
-      "riotHandle": "@dotsamastake.io:matrix.org"
+      "riotHandle": "@dotsamastake.io:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 259,
       "name": "Leostake",
       "stash": "16A7Jq9UWCc86CcQvWZXXqDyMguT5eQjkBUncbmzyvMWRZ21",
       "kusamaStash": "HNGMhUpVnZjuJ3kQcBAMF4KVywdkk2SCxQ4TAt6QBKtMCFh",
-      "riotHandle": "@leostake:matrix.org"
+      "riotHandle": "@leostake:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 260,
       "name": "PathrockNetwork",
       "stash": "15MZqPwJTkmPieNpT3vNXeqZ9S1B5ThmnE8jtqotEVXQoLcE",
       "kusamaStash": "Hk7snkgFNhrDRfwveEdpwgwu6D9uUmXwcLy3dZgM2EhHVJq",
       "riotHandle": "@pathrock:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 261,
       "name": "WDMASTER",
       "stash": "14PkBX3BUF71wDh44BLeNby2u7X9ZBu36V28LMcBrdK35yC2",
       "kusamaStash": "HZsquaFQ3rhBxBgEokxE4ea9gqpj2ZCyZGyXDojH8JYDuzS",
-      "riotHandle": "@wdmaster:matrix.org"
+      "riotHandle": "@wdmaster:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 262,
       "name": "lada",
       "stash": "132XjckpT4rxeYgFxyJn1QdpbeXmG7arFwfnHs7LVS2VVjzh",
       "kusamaStash": "Cn2A8M1tbjYq5BXQWeNs9KKjrkhgbM46UX8BVcUU2qdfV9f",
-      "riotHandle": "@lada-kmv:matrix.org"
+      "riotHandle": "@lada-kmv:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 263,
       "name": "Statute",
       "stash": "16VVLeYXGMXW2kHD5haYKUCXQZfb5XharQeqaHgG2cnywfsZ",
       "kusamaStash": "EVktWq6LPJNpqVababoL2QKwfpBEh7whCqH8tuGrGWbQE1v",
-      "riotHandle": "@statute:matrix.org"
+      "riotHandle": "@statute:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 264,
       "name": "Fialka",
       "stash": "14oRxBkBvuPrEba7MfwQsXEbUcHU2GJxZceRMwtCbHHgSKR4",
       "kusamaStash": "GNkUApzhV9JYiP3AjhTdKmSmaa48dZzwVkgbKAoWzUeztiS",
-      "riotHandle": "@s.stegno:matrix.org"
+      "riotHandle": "@s.stegno:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 265,
       "name": "0xn00bz",
       "stash": "15S8fgRAVzvtfiyxgqWpH1QcUTAj7Mky8gBb3Ys22GzQQV6a",
       "kusamaStash": "CoLVrvRx43NPh8wtDMxY4UoNz1ebSwuu5FwegXj64kJaMkp",
-      "riotHandle": "@0xn00bz:matrix.org"
+      "riotHandle": "@0xn00bz:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 266,
       "name": "rodion",
       "stash": "14i6Wxp8nYxotNCq8MCgTU2j4rV4NGVW9xfrPuxk8qMUtvuC",
       "kusamaStash": "DAnQRPv7SbVhchaVb7tkiYhFCFf8WhfQuH7LTJJSa8yxo6t",
-      "riotHandle": "@rodionpapa007:matrix.org"
+      "riotHandle": "@rodionpapa007:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 267,
       "name": "Aqupidhappy-P",
       "stash": "1Erc6G7Se7AZa4DNcTd4fkXsei3xYmZpPBX9DDU3x8Rn6Kn",
       "kusamaStash": "CpB85LvDDrcsgs9BgDfpUHPAcze4v2cCGHnNaW4yfKQLuP4",
-      "riotHandle": "@qupidvalidator:matrix.org"
+      "riotHandle": "@qupidvalidator:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 268,
       "name": "STRAWBERRY-DOT",
       "stash": "15Dp4nuSJDJknsxJ5JzTVoS4EFxS75KK9Dsokwc86yzSxe3P",
       "kusamaStash": "FZfG7K9Yx7qwHHV9xnaUhnxeUziSCHmcB6K5THZaGuuTdXw",
-      "riotHandle": "@sweetberry:matrix.org"
+      "riotHandle": "@sweetberry:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 269,
       "name": "crypto-jack-sparrow",
       "stash": "17NP1aTyHbS5oMCbtyoayyaFyFBmShCPBDa4fuCX83fjHio",
       "kusamaStash": "Cbm8UMQYmgrhYt4KVah4rFyVE5MH1puA2AvBN3gYB2v2yGU",
-      "riotHandle": "@jacksparrowcrypto:matrix.org"
+      "riotHandle": "@jacksparrowcrypto:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 270,
       "name": "📜 Holy Consensus 📜",
       "stash": "13gWcC6NzYKKnDS2ayZBoUVFWah9uBQgWcTj8tCuHa92Ukmq",
       "kusamaStash": "GhmAcucWFj6gnwJ4y61woEo1fbooXtpLRcLGnDJPuAvGCRB",
-      "riotHandle": "@mogioman:matrix.org"
+      "riotHandle": "@mogioman:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 271,
       "name": "lightning-strike",
       "stash": "15dLWAUwegTVMNivZS8iTDyxSu2yYkBAk4ePvE3MYgjj9CJw",
       "kusamaStash": "CzPKgpYLTrhebtheB2GsM19WFtgH66fv9fjChuHGjzRyVpe",
-      "riotHandle": "@smoke26:matrix.org"
+      "riotHandle": "@smoke26:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 272,
       "name": "Perfect-node",
       "stash": "12uUKHVCpXuqVgsm8XxLE56cyHNyvKXMNLJTUJ2j3R7xke7w",
       "kusamaStash": "EaEcqkSUo1TVY4q3sz5uQLqdtpcgRm17qMHQko9cLKPH6RA",
       "riotHandle": "@perfect-node:matrix.org",
-      "skipSelfStake": true
+      "skipSelfStake": true,
+      "kyc": false
     },
     {
+      "slotId": 273,
       "name": "HYPERSPEED_DOT1",
       "stash": "1qUKZLhxVGUPozs8j8XpxH8VbZX5ckXV7ziUf6ji83ieZYd",
       "kusamaStash": "HRs3r9sUx16zv1ihw12ztch7a5gNFzuHnSx77HdXsHfEY1V",
-      "riotHandle": "@lokal:matrix.org"
+      "riotHandle": "@lokal:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 274,
       "name": "abgar",
       "stash": "12zqozWYvokd2pN7Rr9JEtpfxAcUP7UmwS7ocGmf7rXpLeFG",
       "kusamaStash": "GjrCYnVS59dsRkydpM6QSRLvpoR8MUPnkyVS3SNWqsxWW7r",
-      "riotHandle": "@abgar:matrix.org"
+      "riotHandle": "@abgar:matrix.org",
+      "kyc": false
     },
     {
+      "slotId": 275,
       "name": "futureproof",
       "stash": "13unkT9DyFUnzKZdLCkHBvGLuhvcHQSrRhTWhrL9gqG98CTH",
       "kusamaStash": "J3f7ULfjVbbBYvZtMvaEDiUC8odXjt2A2hGShshBFCKHazY",
       "riotHandle": "@kureus:matrix.org",
-      "kyc": true
+      "kyc": false
     },
     {
+      "slotId": 276,
       "name": "🌲🌳Plant A Tree🌳🌲",
       "stash": "13dTrEE587xf5Kwgiegg4bWfWEw4KRZcDpmFRw9jLBofvyMK",
       "kusamaStash": "JFHtREewUeVy96gGDwMTxrGvQxBDz6jGL8E5LxnAnNbcNbh",
       "riotHandle": "@plant-a-tree:matrix.org",
-      "kyc": true
+      "kyc": false
     },
     {
+      "slotId": 277,
       "name": "🕴TUXEDO🕴",
       "stash": "16cSiUTqGavZULqZStC6wvCxiFrtQmUafsDknoTmhAbMT6Jz",
       "kusamaStash": "FGHknsDq3UwZDgtvpGE6bK2Z1csVgrY5xCEA1H1kapZ8bxn",
       "riotHandle": "@tux_in_tuxedo:matrix.org",
-      "kyc": true
+      "kyc": false
     }
   ]
 }


### PR DESCRIPTION
- adds a unique `slotId` to all candidates which should help in maintaining consistency
- adds a `kyc` field to candidates that don't already have one (defaults to `false`)
- Nothing else is changed for any candidates besides adding those fields for everyone where they don't already exist


This should be merged before #2586 , so that the new CI checks introduced in that PR will pass (as it checks that all those fields exist on all candidates)