### PR TITLE
Update Stash account of the Node "Sik | crifferent(dot)de"

### DIFF
--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -1067,7 +1067,7 @@
     {
       "slotId": 131,
       "name": "Sik | crifferent(dot)de",
-      "stash": "15wepZh1jWNqxBjsgErm8HmYiE21n79c5krQJeTsYAjHddeM",
+      "stash": "14m8CmDmksk4cQ5YtvQzRva7J7B2gLCSSD8dwPfyH6WUahrG",
       "kusamaStash": "HWyLYmpW68JGJYoVJcot6JQ1CJbtUQeTdxfY1kUTsvGCB1r",
       "riotHandle": "@dev0_sik:matrix.org",
       "skipSelfStake": true,


### PR DESCRIPTION
Updating the stash address for @dev0_sik:matrix.org.

Previous: 15wepZh1jWNqxBjsgErm8HmYiE21n79c5krQJeTsYAjHddeM
New: 14m8CmDmksk4cQ5YtvQzRva7J7B2gLCSSD8dwPfyH6WUahrG