### PR TITLE
Changed 1 stash and node name

### DIFF
--- a/candidates/kusama.json
+++ b/candidates/kusama.json
@@ -4309,8 +4309,8 @@
     },
     {
       "slotId": 618,
-      "name": "ULTRA/N1",
-      "stash": "GVGsDZBoccL1YFnJS8RCpYE6aT2sXZkKtfSTJhkXD2MBrmJ",
+      "name": "ULTRA/N2",
+      "stash": "FFrG8RuDF5taxGp5RyhnsB9iHKvne2Ndw5nF777B3VZHCFR",
       "riotHandle": "@ultranodes:matrix.org",
       "kyc": false
     },

--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -1821,8 +1821,8 @@
       "slotId": 222,
       "name": "ULTRA-DOT-1",
       "stash": "13xN9Mw1Xif5VTd9RdVEjaYjPsZAZeSKbukuDVHzxAjGjJ1Q",
-      "kusamaStash": "GVGsDZBoccL1YFnJS8RCpYE6aT2sXZkKtfSTJhkXD2MBrmJ",
-      "riotHandle": "@ultranode:matrix.org",
+      "kusamaStash": "FFrG8RuDF5taxGp5RyhnsB9iHKvne2Ndw5nF777B3VZHCFR",
+      "riotHandle": "@ultranodes:matrix.org",
       "kyc": false
     },
     {


### PR DESCRIPTION
Changed stash and name for one node for `@ultranodes:matrix.org` after participant's request.

- Stash: `GVGsDZBoccL1YFnJS8RCpYE6aT2sXZkKtfSTJhkXD2MBrmJ` to  `FFrG8RuDF5taxGp5RyhnsB9iHKvne2Ndw5nF777B3VZHCFR`
- Name: `ULTRA/N1` to `ULTRA/N2`
- Updated Kusama stash also in polkadot.json after change in kusama.json
- Fixed typo in matrix handle in polkadot.json