### PR TITLE
v3.1.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
           name: Run Tests
           command: |
             export MONGO_URI="mongodb://mongodb:27017/testdb"
-            yarn workspace @1kv/telemetry test:int
+            yarn build && yarn workspace @1kv/telemetry test:int
 
   helmLint:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,25 @@ jobs:
             export MONGO_URI="mongodb://mongodb:27017/testdb"
             yarn workspace @1kv/common test:scorekeeper:int
 
+  TelemetryIntegrationTests:
+    description: "Telemetry Integration Tests"
+    docker:
+      - image: node:18-bullseye
+      - image: mongo:6.0.9
+        name: mongodb
+
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Install Dependencies
+          command: yarn install --immutable
+      - run:
+          name: Run Tests
+          command: |
+            export MONGO_URI="mongodb://mongodb:27017/testdb"
+            yarn workspace @1kv/telemetry test:int
+
   helmLint:
     docker:
       - image: web3f/ci-commons:v3.2.3
@@ -296,23 +315,23 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-
       - ChaindataIntegrationTests:
           filters:
             tags:
               ignore: /.*/
-
       - ApiHandlerIntegrationTests:
           filters:
             tags:
               ignore: /.*/
-
       - NominatorIntegrationTests:
           filters:
             tags:
               ignore: /.*/
-
       - ScorekeeperIntegrationTests:
+          filters:
+            tags:
+              ignore: /.*/
+      - TelemetryIntegrationTests:
           filters:
             tags:
               ignore: /.*/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ docs/.DS_Store
 build/**
 dist/**
 .next/**
+coverage/**

--- a/apps/1kv-backend-staging/templates/kusama-otv-backend.yaml
+++ b/apps/1kv-backend-staging/templates/kusama-otv-backend.yaml
@@ -57,7 +57,6 @@ spec:
                   "skipConnectionTime": true,
                   "skipIdentity": false,
                   "skipClientUpgrade": false,
-                  "forceClientVersion": "v0.9.39",
                   "skipUnclaimed": true,
                   "minSelfStake": 10000000000000,
                   "commission": 150000000,

--- a/apps/1kv-backend-staging/templates/polkadot-otv-backend.yaml
+++ b/apps/1kv-backend-staging/templates/polkadot-otv-backend.yaml
@@ -56,7 +56,6 @@ spec:
                   "skipConnectionTime": false,
                   "skipIdentity": false,
                   "skipClientUpgrade": false,
-                  "forceClientVersion": "v0.9.39",
                   "skipUnclaimed": true,
                   "minSelfStake": 50000000000000,
                   "commission": 50000000,

--- a/apps/1kv-backend/templates/kusama-otv-backend.yaml
+++ b/apps/1kv-backend/templates/kusama-otv-backend.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     repoURL: https://w3f.github.io/helm-charts/
     chart: otv-backend
-    targetRevision: v3.1.7
+    targetRevision: v3.1.8
     plugin:
       env:
         - name: HELM_VALUES
@@ -55,7 +55,6 @@ spec:
                   "skipIdentity": false,
                   "skipStakedDestination": true,
                   "skipClientUpgrade": false,
-                  "forceClientVersion": "v0.9.39",
                   "skipUnclaimed": true,
                   "minSelfStake": 10000000000000,
                   "commission": 150000000,

--- a/apps/1kv-backend/templates/polkadot-otv-backend.yaml
+++ b/apps/1kv-backend/templates/polkadot-otv-backend.yaml
@@ -17,7 +17,7 @@ spec:
   source:
     repoURL: https://w3f.github.io/helm-charts/
     chart: otv-backend
-    targetRevision: v3.1.7
+    targetRevision: v3.1.8
     plugin:
       env:
         - name: HELM_VALUES
@@ -54,7 +54,6 @@ spec:
                   "skipIdentity": false,
                   "skipStakedDestination": true,
                   "skipClientUpgrade": false,
-                  "forceClientVersion": "v0.9.39",
                   "skipUnclaimed": true,
                   "minSelfStake": 50000000000000,
                   "commission": 50000000,

--- a/charts/otv-backend/Chart.yaml
+++ b/charts/otv-backend/Chart.yaml
@@ -1,5 +1,5 @@
 description: 1K Validators Backend
 name: otv-backend
-version: v3.1.7
-appVersion: v3.1.7
+version: v3.1.8
+appVersion: v3.1.8
 apiVersion: v2

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     "test:common:int:apihandler:ci": "circleci local execute ApiHandlerIntegrationTests",
     "test:common:int:nominator:ci": "circleci local execute NominatorIntegrationTests",
     "test:common:int:ci": "yarn test:common:int:scorekeeper:ci && yarn test:common:int:chaindata:ci && yarn test:common:int:apihandler:ci && yarn test:common:int:nominator:ci",
+    "test:telemetry:int:ci": "circleci local execute TelemetryIntegrationTests",
+    "test:ci:all": "yarn test:common:int:ci && yarn test:telemetry:int:ci",
     "test:all": "yarn workspaces foreach run test",
     "test": "LOG_LEVEL=warn yarn build && vitest run --coverage --config vitest.config.mts",
     "test:ui": "LOG_LEVEL=warn vitest --ui --config vitest.config.mts --coverage",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1kv/common",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Services for running the Thousand Validator Program.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -12,6 +12,10 @@ export const WEEK = 7 * 24 * 60 * 60 * 1000;
 /// The time a node has to make an upgrade to the latest release.
 export const SIXTEEN_HOURS = 16 * 60 * 60 * 1000;
 
+export const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+
+export const FORTY_EIGHT_HOURS = 48 * 60 * 60 * 1000;
+
 export const GATEWAY_CACHE_TTL = 18 * 1000;
 
 /// Number of Eras in 4 days that a validator should have claimed all previous rewards except

--- a/packages/common/src/constraints/ValidityChecks.ts
+++ b/packages/common/src/constraints/ValidityChecks.ts
@@ -106,7 +106,10 @@ export const checkLatestClientVersion = async (
         `No latest release found, fetching from GitHub`,
         constraintsLabel,
       );
-      latestRelease = await getLatestTaggedRelease();
+      // fetch from github and set in the db
+      await getLatestTaggedRelease();
+      // get the record from the db
+      latestRelease = await getLatestRelease();
       logger.info(
         `Latest release fetched from GitHub: ${latestRelease}`,
         constraintsLabel,

--- a/packages/common/src/constraints/ValidityChecks.ts
+++ b/packages/common/src/constraints/ValidityChecks.ts
@@ -116,12 +116,20 @@ export const checkLatestClientVersion = async (
       );
     }
 
+    // Ensure latestRelease contains a valid name
+    if (!latestRelease || !latestRelease.name) {
+      logger.error(
+        `Latest release name is null or undefined: ${latestRelease}`,
+        constraintsLabel,
+      );
+      return false;
+    }
+
     // Check if there is a latest release and if the current time is past the grace window
     const isPastGraceWindow =
-      latestRelease &&
-      Date.now() > latestRelease.publishedAt + Constants.SIXTEEN_HOURS;
+      Date.now() > latestRelease.publishedAt + Constants.FORTY_EIGHT_HOURS;
 
-    if (latestRelease && isPastGraceWindow) {
+    if (isPastGraceWindow) {
       const nodeVersion = semver.coerce(candidate.version);
       const latestVersion = forceLatestRelease
         ? semver.clean(forceLatestRelease)
@@ -140,7 +148,7 @@ export const checkLatestClientVersion = async (
 
       const isUpgraded = semver.gte(nodeVersion, latestVersion);
 
-      // If they are not upgrade, set the validity as invalid
+      // If they are not upgraded, set the validity as invalid
       if (!isUpgraded) {
         await setLatestClientReleaseValidity(candidate.stash, false);
         return false;
@@ -150,7 +158,7 @@ export const checkLatestClientVersion = async (
       await setLatestClientReleaseValidity(candidate.stash, true);
       return true;
     } else {
-      // If there is no latest release or if not past the grace window, set the release as invalid
+      // If not past the grace window, set the release as invalid
       await setLatestClientReleaseValidity(candidate.stash, false);
       return false;
     }
@@ -182,7 +190,6 @@ export const checkConnectionTime = async (
       await setConnectionTimeInvalidity(candidate.stash, true);
       return true;
     }
-    return true;
   } catch (e) {
     logger.error(`Error checking connection time: ${e}`, constraintsLabel);
     return false;
@@ -254,7 +261,6 @@ export const checkCommission = async (
       await setCommissionInvalidity(candidate.stash, true);
       return true;
     }
-    return true;
   } catch (e) {
     logger.error(`Error checking commission: ${e}`, constraintsLabel);
     return false;
@@ -317,7 +323,6 @@ export const checkUnclaimed = async (
       await setUnclaimedInvalidity(candidate.stash, true);
       return true;
     }
-    return true;
   } catch (e) {
     logger.error(`Error checking unclaimed: ${e}`, constraintsLabel);
     return false;
@@ -339,7 +344,6 @@ export const checkBlocked = async (
       await setBlockedInvalidity(candidate.stash, true);
       return true;
     }
-    return true;
   } catch (e) {
     logger.error(`Error checking blocked: ${e}`, constraintsLabel);
     return false;
@@ -376,7 +380,6 @@ export const checkProvider = async (
       await setProviderInvalidity(candidate.stash, true);
       return true;
     }
-    return true;
   } catch (e) {
     logger.error(`Error checking provider: ${e}`, constraintsLabel);
     return false;

--- a/packages/common/src/db/queries/Candidate.ts
+++ b/packages/common/src/db/queries/Candidate.ts
@@ -636,7 +636,7 @@ export const reportOffline = async (name: string): Promise<boolean> => {
           {
             offlineSince: Date.now(),
             onlineSince: 0,
-            $inc: { nodeRefs: -1 },
+            nodeRefs: 0,
           },
         ).exec();
         await updateCandidateOfflineValidity(name);

--- a/packages/common/src/db/queries/Release.ts
+++ b/packages/common/src/db/queries/Release.ts
@@ -17,5 +17,14 @@ export const setRelease = async (
 };
 
 export const getLatestRelease = async (): Promise<any> => {
-  return (await ReleaseModel.find({}).lean().sort("-publishedAt").limit(1))[0];
+  try {
+    const latestRelease = await ReleaseModel.findOne({})
+      .sort("-publishedAt")
+      .lean()
+      .limit(1);
+    return latestRelease;
+  } catch (error) {
+    console.error("Error while fetching latest release:", error);
+    throw error;
+  }
 };

--- a/packages/common/src/monitor.ts
+++ b/packages/common/src/monitor.ts
@@ -39,8 +39,13 @@ export default class Monitor {
     const { tag_name, published_at } = latestRelease.data;
     const publishedAt = new Date(published_at).getTime();
 
-    const tagParts = tag_name.split("-");
-    const version = tagParts[tagParts.length - 1];
+    // Extract version number from the tag name
+    const versionMatch = tag_name.match(/v?(\d+\.\d+\.\d+)/);
+    if (!versionMatch) {
+      logger.warn(`Unable to extract version from tag name: ${tag_name}`);
+      return null;
+    }
+    const version = versionMatch[1]; // Extracted version number
 
     await queries.setRelease(version, publishedAt);
 

--- a/packages/common/src/monitor.ts
+++ b/packages/common/src/monitor.ts
@@ -39,10 +39,10 @@ export default class Monitor {
     const { tag_name, published_at } = latestRelease.data;
     const publishedAt = new Date(published_at).getTime();
 
-    await queries.setRelease(tag_name, publishedAt);
-
     const tagParts = tag_name.split("-");
     const version = tagParts[tagParts.length - 1];
+
+    await queries.setRelease(version, publishedAt);
 
     if (
       this.latestTaggedRelease &&

--- a/packages/common/src/monitor.ts
+++ b/packages/common/src/monitor.ts
@@ -41,21 +41,24 @@ export default class Monitor {
 
     await queries.setRelease(tag_name, publishedAt);
 
+    const tagParts = tag_name.split("-");
+    const version = tagParts[tagParts.length - 1];
+
     if (
       this.latestTaggedRelease &&
-      tag_name === this.latestTaggedRelease!.name
+      version === this.latestTaggedRelease!.name
     ) {
       logger.info("(Monitor::getLatestTaggedRelease) No new release found");
       return null;
     }
 
     this.latestTaggedRelease = {
-      name: tag_name.split(`-`)[1],
+      name: version,
       publishedAt,
     };
 
     logger.info(
-      `(Monitor::getLatestTaggedRelease) Latest release updated: ${tag_name} | Published at: ${publishedAt}`,
+      `(Monitor::getLatestTaggedRelease) Latest release updated: ${version} | Published at: ${publishedAt}`,
     );
 
     return this.latestTaggedRelease;

--- a/packages/common/test/testUtils/dbUtils.ts
+++ b/packages/common/test/testUtils/dbUtils.ts
@@ -122,6 +122,7 @@ export const initTestServerBeforeAll = () => {
   afterEach(async () => {});
 
   afterAll(async () => {
+    await mongoose.connection.dropDatabase();
     await mongoose.disconnect();
   });
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1kv/core",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Services for running the Thousand Validator Program.",
   "main": "index.js",
   "scripts": {

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1kv/gateway",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Services for running the Thousand Validator Program.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/gateway/src/routes/index.ts
+++ b/packages/gateway/src/routes/index.ts
@@ -9,6 +9,8 @@ import Location from "../controllers/Location";
 import Validator from "../controllers/Validators";
 import Rewards from "../controllers/Rewards";
 import Block from "../controllers/Block";
+import { response } from "../controllers";
+import { queries } from "@1kv/common";
 
 const router: any = new Router();
 
@@ -126,5 +128,9 @@ router.get(API.BlockIndex, Block.getBlockIndex);
 
 router.get(API.StatsTotalReqeusts, Stats.getTotalRequests);
 router.get(API.StatsEndpointCounts, Stats.getEndpointCounts);
+
+router.get(API.Release, async (ctx: any) => {
+  response(ctx, 200, await queries.getLatestRelease());
+});
 
 export default router;

--- a/packages/scorekeeper-status-ui/package.json
+++ b/packages/scorekeeper-status-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@1kv/scorekeeper-status-ui",
   "private": true,
-  "version": "3.1.7",
+  "version": "3.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1kv/telemetry",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Services for running the Thousand Validator Program.",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -20,6 +20,7 @@
     "start:watch": "NODE_OPTIONS='--max-old-space-size=6096' nodemon --watch build --exec node build/run.js",
     "start:dev": "concurrently \"tsc -w\"  \"yarn start:watch\"",
     "js:start": "NODE_OPTIONS='--max-old-space-size=6096' node build/run.js start",
+    "test": "SKIP_MD5=true LOG_LEVEL=info ../../node_modules/.bin/vitest --config vitest.int.config.mts --no-file-parallelism",
     "test:int": "SKIP_MD5=true LOG_LEVEL=info ../../node_modules/.bin/vitest --config vitest.int.config.mts --no-file-parallelism",
     "test:int:silent": "SKIP_MD5=true LOG_LEVEL=warn ../../node_modules/.bin/vitest --config vitest.int.config.mts --no-file-parallelism"
   },

--- a/packages/telemetry/test/utils.ts
+++ b/packages/telemetry/test/utils.ts
@@ -28,10 +28,14 @@ export const initTestServerBeforeAll = () => {
     await createTestServer();
   });
 
-  beforeEach(async () => {});
+  beforeEach(async () => {
+    const dbName = `testdb_${Date.now()}`;
+    await mongoose.connection.useDb(dbName);
+  });
   afterEach(async () => {});
 
   afterAll(async () => {
+    await mongoose.connection.dropDatabase();
     await mongoose.disconnect();
   });
 };

--- a/packages/telemetry/vitest.int.config.mts
+++ b/packages/telemetry/vitest.int.config.mts
@@ -7,5 +7,6 @@ export default defineConfig({
         testTimeout: 130000,
         retry: 1,
         setupFiles: ["test/vitest.setup.ts"],
+        maxConcurrency: 1,
     },
 });

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1kv/worker",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Services for running the Thousand Validator Program.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,5 +1,6 @@
 import {defineConfig} from "vitest/config";
 
+
 export default defineConfig({
   test: {
     globals: true,
@@ -12,10 +13,20 @@ export default defineConfig({
       exclude: ['/docs/**', 'node_modules/**']
     },
 
-    include: ["src/**/*.ts"],
 
-    exclude: ["node_modules/**", "dist/**", "packages/scorekeeper-status-ui/**", "docs/**"],
+    // @ts-ignore
+    common: {
+      include: ["packages/common/**/*.test.ts"],
+      setupFiles: ["packages/common/test/vitest.setup.ts"],
+      exclude: ["node_modules/**", "dist/**", "packages/scorekeeper-status-ui/**", "docs/**"],
+    },
 
+    // @ts-ignore
+    telemetry: {
+      include: ["packages/telemetry/**/*.test.ts"],
+      setupFiles: ["packages/telemetry/test/vitest.setup.ts"],
+      exclude: ["node_modules/**", "dist/**", "packages/scorekeeper-status-ui/**", "docs/**"],
+    },
 
   },
 });


### PR DESCRIPTION
- Enables Telemetry integration tests in CI
- removes `forceClientVersion` versions from configs
- adjusts version checking https://github.com/w3f/1k-validators-be-PRIVATE/issues/73
- Changes release grace window to be 48 hours