### PR TITLE
skipSelfStake parameter decentraDOT

### DIFF
--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -1128,6 +1128,7 @@
       "stash": "15wznkm7fMaJLFaw7B8KrJWkNcWsDziyTKVjrpPhRLMyXsr5",
       "kusamaStash": "GRSWBC1kCuNVp8KTgGyK7Bo3bP7CdLDPwfnx2L5JJLQ41Qj",
       "riotHandle": "@arthurhoeke:matrix.org",
+      "skipSelfStake": true,
       "kyc": false
     },
     {


### PR DESCRIPTION
Hi W3F,

We would like to request our Polkadot validator to receive the skipSelfStake parameter due to our work on the development and hosting of our validator dashboard [Cyclops](https://dashboard.decentradot.com/).

We received a grant for this project about a year ago (https://github.com/w3f/Grants-Program/blob/master/applications/cyclops.md) and continue to host and maintain the project, which is actively used by other 1kv members and validator operators.

If this is not the right channel or if we should contact a team member please let me know,

Thank you!