### PR TITLE
Update stash address and telemetry name for Khastor

### DIFF
--- a/candidates/kusama.json
+++ b/candidates/kusama.json
@@ -1700,8 +1700,8 @@
     },
     {
       "slotId": 242,
-      "name": "Khastor-KVN01",
-      "stash": "D6NNbc18fTh4WVQtmrTyLRHGv8SKVtjKFY8uV34k5ydBMaV",
+      "name": "Khastor-KVN03",
+      "stash": "H4F8kJeJ8anTS1WUZATDaj6WfYzoxCvARaDFzQkN6pKzvvV",
       "riotHandle": "@khastor:matrix.org",
       "kyc": false
     },

--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -870,7 +870,7 @@
       "slotId": 107,
       "name": "Khastor-PVN01",
       "stash": "1429tQ2RK8xCwiVYYw7YVUFGX2rbASQN2maMExay7x18neoZ",
-      "kusamaStash": "D6NNbc18fTh4WVQtmrTyLRHGv8SKVtjKFY8uV34k5ydBMaV",
+      "kusamaStash": "H4F8kJeJ8anTS1WUZATDaj6WfYzoxCvARaDFzQkN6pKzvvV",
       "riotHandle": "@khastor:matrix.org",
       "kyc": false
     },


### PR DESCRIPTION
The participant requested this change over email.

Old stash: `D6NNbc18fTh4WVQtmrTyLRHGv8SKVtjKFY8uV34k5ydBMaV`
New stash: `H4F8kJeJ8anTS1WUZATDaj6WfYzoxCvARaDFzQkN6pKzvvV`

Old name: `Khastor-KVN01`
New name: `Khastor-KVN03`