### PR TITLE
update decentraDOT stash

### DIFF
--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -1125,7 +1125,7 @@
     {
       "slotId": 138,
       "name": "decentraDOT",
-      "stash": "15wznkm7fMaJLFaw7B8KrJWkNcWsDziyTKVjrpPhRLMyXsr5",
+      "stash": "12QTG1GrqFtS6AJWw4NwHDXgbhPyjyT6BfJK5qAGedkvnrpQ",
       "kusamaStash": "GRSWBC1kCuNVp8KTgGyK7Bo3bP7CdLDPwfnx2L5JJLQ41Qj",
       "riotHandle": "@arthurhoeke:matrix.org",
       "kyc": false


### PR DESCRIPTION
We'd like to update our Polkadot validator stash, seeing our first validator is now occasionally independently in the active set.

Thank you