### PR TITLE
Fix Docusarus Endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN echo "building ${PACKAGE}... "; \
     yarn install; \
     echo "yarn install done. Building...." ; \
-    yarn turbo; \
+    yarn build; \
     echo "building ${PACKAGE} done."; \
     apt-get update && \
     apt-get clean

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -8,7 +8,7 @@ WORKDIR /code
 RUN echo "building ${PACKAGE}... "; \
     yarn install; \
     echo "yarn install done. Building...." ; \
-    yarn turbo; \
+    yarn build; \
     echo "building ${PACKAGE} done."; \
     apt-get update && \
     apt-get install -y libssl-dev && \


### PR DESCRIPTION
- fixes `/docs` endpoint, which was broken with the v3.1.7 release

closes https://github.com/w3f/1k-validators-be-PRIVATE/issues/72