### PR TITLE
Query only past 84 eras of Era Points

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -207,3 +207,5 @@ export const USE_PROVIDER = true;
 export const USE_NOMINATIONS = true;
 export const USE_RPC = true;
 export const USE_CLIENT = true;
+
+export const MAX_ERAS_POINTS = 85;

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -208,4 +208,4 @@ export const USE_NOMINATIONS = true;
 export const USE_RPC = true;
 export const USE_CLIENT = true;
 
-export const MAX_ERAS_POINTS = 85;
+export const ERAPOINTS_JOB_MAX_ERAS = 84;

--- a/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
@@ -63,20 +63,15 @@ export const eraPointsJob = async (
     //    - if a record doesn't exist, create it
     const [activeEra, err] = await chaindata.getActiveEraIndex();
 
-    // Calculate total number of eras to process
-    const totalEras = activeEra;
-    let processedEras = 0;
-
     for (
-      let i = activeEra - 1;
-      i >= activeEra - Constants.MAX_ERAS_POINTS;
-      i--
+      let i = activeEra - 1, processedEras = 1;
+      i >= activeEra - Constants.ERAPOINTS_JOB_MAX_ERAS;
+      i--, processedEras ++
     ) {
       await individualEraPointsJob(chaindata, i);
 
       // Calculate progress percentage
-      processedEras++;
-      const progress = (processedEras / totalEras) * 100;
+      const progress = (processedEras / Constants.ERAPOINTS_JOB_MAX_ERAS) * 100;
 
       // Emit progress update with active era as iteration
       jobStatusEmitter.emit("jobProgress", {

--- a/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
@@ -66,7 +66,7 @@ export const eraPointsJob = async (
     for (
       let i = activeEra - 1, processedEras = 1;
       i >= activeEra - Constants.ERAPOINTS_JOB_MAX_ERAS;
-      i--, processedEras ++
+      i--, processedEras++
     ) {
       await individualEraPointsJob(chaindata, i);
 

--- a/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
@@ -1,4 +1,4 @@
-import { ChainData, logger, queries } from "../../../index";
+import { ChainData, Constants, logger, queries } from "../../../index";
 import { Job, JobConfig, JobRunnerMetadata, JobStatus } from "../JobsClass";
 import { jobStatusEmitter } from "../../../Events";
 import { withExecutionTimeLogging } from "../../../utils";
@@ -67,7 +67,11 @@ export const eraPointsJob = async (
     const totalEras = activeEra;
     let processedEras = 0;
 
-    for (let i = activeEra - 1; i >= activeEra - 85; i--) {
+    for (
+      let i = activeEra - 1;
+      i >= activeEra - Constants.MAX_ERAS_POINTS;
+      i--
+    ) {
       await individualEraPointsJob(chaindata, i);
 
       // Calculate progress percentage

--- a/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
@@ -67,7 +67,7 @@ export const eraPointsJob = async (
     const totalEras = activeEra;
     let processedEras = 0;
 
-    for (let i = activeEra - 1; i >= 0; i--) {
+    for (let i = activeEra - 1; i >= activeEra - 85; i--) {
       await individualEraPointsJob(chaindata, i);
 
       // Calculate progress percentage


### PR DESCRIPTION
- The entire chain doesn't need to be queried, this queries only the past 84 eras of era points. 
- fixes https://github.com/w3f/1k-validators-be-PRIVATE/issues/71