### PR TITLE
Update polkadot.json

### DIFF
--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -214,8 +214,8 @@
     },
     {
       "slotId": 26,
-      "name": "Mile-Bravo",
-      "stash": "1HmAqbBRrWvsqbLkvpiVDkdA2PcctUE5JUe3qokEh1FN455",
+      "name": "Mile-Charlie",
+      "stash": "1ChAR84s9n6ZTYGSJqkKizzdnJBarK85bxficpxrd8CkGt4",
       "kusamaStash": "HMaTJbeYonb2SoT7ek1sjrtkkKaor7j3yy2VUbj6FDokPXr",
       "riotHandle": "@matherceg:matrix.org",
       "kyc": false


### PR DESCRIPTION
Mile-Bravo stash (1HmAqbBRrWvsqbLkvpiVDkdA2PcctUE5JUe3qokEh1FN455) replaced with Mile-Charlie (1ChAR84s9n6ZTYGSJqkKizzdnJBarK85bxficpxrd8CkGt4).