### PR TITLE
stats: support scoring of single item vectors

### DIFF
--- a/packages/common/src/constraints/score.ts
+++ b/packages/common/src/constraints/score.ts
@@ -99,7 +99,7 @@ export const getStats = (arr: number[]): Stats => {
   const arrQ75 = arr.length !== 0 ? q75(arr) : 0;
   const arrQ90 = arr.length !== 0 ? q90(arr) : 0;
   const arrMean = arr.length !== 0 ? mean(arr) : 0;
-  const arrStd = arr.length !== 0 ? std(arr) : 0;
+  const arrStd = arr.length > 1 ? std(arr) : 0;
 
   return {
     values: arr,


### PR DESCRIPTION
The current `std` implementation only works for arrays that have at least two elements, as with just one element it ends up [dividing by zero](https://github.com/w3f/1k-validators-be/blob/master/packages/common/src/constraints/score.ts#L20-L24). This then initializes all `standardDeviation` to `NaN` and as a result ends up breaking the scoring with following trace:

```json
{
  "errors": {
    "bondedStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "bondedStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"bondedStats.standardDeviation\""
    },
    "faultsStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "faultsStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"faultsStats.standardDeviation\""
    },
    "inclusionStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "inclusionStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"inclusionStats.standardDeviation\""
    },
    "spanInclusionStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "spanInclusionStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"spanInclusionStats.standardDeviation\""
    },
    "discoveredAtStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "discoveredAtStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"discoveredAtStats.standardDeviation\""
    },
    "nominatedAtStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "nominatedAtStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"nominatedAtStats.standardDeviation\""
    },
    "offlineStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "offlineStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"offlineStats.standardDeviation\""
    },
    "rankStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "rankStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"rankStats.standardDeviation\""
    },
    "locationStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "locationStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"locationStats.standardDeviation\""
    },
    "regionStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "regionStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"regionStats.standardDeviation\""
    },
    "countryStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "countryStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"countryStats.standardDeviation\""
    },
    "providerStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "providerStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"providerStats.standardDeviation\""
    },
    "nominatorStakeStats.standardDeviation": {
      "stringValue": "\"NaN\"",
      "valueType": "number",
      "kind": "Number",
      "value": null,
      "path": "nominatorStakeStats.standardDeviation",
      "reason": {
        "generatedMessage": true,
        "code": "ERR_ASSERTION",
        "actual": false,
        "expected": true,
        "operator": "=="
      },
      "name": "CastError",
      "message": "Cast to Number failed for value \"NaN\" (type number) at path \"nominatorStakeStats.standardDeviation\""
    }
  },
  "_message": "ValidatorScoreMetadata validation failed",
  "name": "ValidationError",
  "message": "ValidatorScoreMetadata validation failed: bondedStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"bondedStats.standardDeviation\", faultsStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"faultsStats.standardDeviation\", inclusionStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"inclusionStats.standardDeviation\", spanInclusionStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"spanInclusionStats.standardDeviation\", discoveredAtStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"discoveredAtStats.standardDeviation\", nominatedAtStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"nominatedAtStats.standardDeviation\", offlineStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"offlineStats.standardDeviation\", rankStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"rankStats.standardDeviation\", locationStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"locationStats.standardDeviation\", regionStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"regionStats.standardDeviation\", countryStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"countryStats.standardDeviation\", providerStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"providerStats.standardDeviation\", nominatorStakeStats.standardDeviation: Cast to Number failed for value \"NaN\" (type number) at path \"nominatorStakeStats.standardDeviation\""
}
```
