### PR TITLE
EraPointsJob: ensure reliable and correct retrieval of era points

### DIFF
--- a/packages/common/src/chaindata/queries/Era.ts
+++ b/packages/common/src/chaindata/queries/Era.ts
@@ -204,12 +204,12 @@ export const findEraBlockHash = async (
         return ["", "API at block hash is null"];
       }
 
-      const testEra = await apiAt.query.staking.currentEra();
+      const testEra = await apiAt.query.staking.activeEra();
       if (testEra && testEra.isEmpty) {
         logger.info(`Test era is empty: ${JSON.stringify(testEra)}`);
         return ["", "Test era is none"];
       }
-      const testIndex = testEra.unwrap().toNumber();
+      const testIndex = testEra.unwrap().index.toNumber();
       if (era == testIndex) {
         return [blockHash.toString(), null];
       }

--- a/packages/common/src/chaindata/queries/Era.ts
+++ b/packages/common/src/chaindata/queries/Era.ts
@@ -46,7 +46,10 @@ export const getTotalEraPoints = async (
     if (!chainType) {
       return {} as EraPointsInfo;
     }
-    const [blockHash, err] = await chaindata.findEraBlockHash(era, chainType);
+    const [blockHash, err] = await chaindata.findEraBlockHash(
+      era + 1,
+      chainType,
+    );
 
     if (blockHash) {
       const apiAt = await chaindata?.api?.at(blockHash);


### PR DESCRIPTION
This PR contains to fixes that probably should be applied together.

 - Firstly, it ensures that `findEraBlockHash` checks the `activeEra` instead of `currentEra`, just as it does inside of [`findEraBlockNumber`](https://github.com/Analog-Labs/1k-validators-be/blob/becc84d4fbc3ed99827193dfced0cbf990d7f563/packages/common/src/chaindata/queries/Era.ts#L281-L282). 
 - Secondly, the `EraPointsJob` uses the state from the next era, ensuring the retrieved era points were actually fully computed.

These two combined now ensure that the backend consistently retrieves the correct era rewards, without it would either fail (hash to early) or retrieve half computed scores. 