### PR TITLE
skipIdentity: add missing implementation

### DIFF
--- a/packages/common/src/constraints/CheckCandidates.ts
+++ b/packages/common/src/constraints/CheckCandidates.ts
@@ -62,7 +62,11 @@ export const checkCandidate = async (
       );
     }
 
-    const identityValid = await checkIdentity(constraints.chaindata, candidate);
+    const identityValid = await checkIdentity(
+      constraints.config,
+      constraints.chaindata,
+      candidate,
+    );
     if (!identityValid) {
       logger.info(`${candidate.name} identity not valid`, constraintsLabel);
     }

--- a/packages/common/src/constraints/ValidityChecks.ts
+++ b/packages/common/src/constraints/ValidityChecks.ts
@@ -203,10 +203,16 @@ export const checkConnectionTime = async (
 };
 
 export const checkIdentity = async (
+  config: Config.ConfigSchema,
   chaindata: ChainData,
   candidate: Candidate,
 ): Promise<boolean> => {
   try {
+    const skipIdentity = config.constraints?.skipIdentity || false;
+    if (skipIdentity) {
+      await setIdentityInvalidity(candidate, true);
+      return true;
+    }
     const [hasIdentity, verified] = await chaindata.hasIdentity(
       candidate.stash,
     );


### PR DESCRIPTION
Currently the `skipIdentity` flag does nothing. This PR adds the missing implementation of this flag, resulting in the identity check to be skipped and marked as successful if the flag is now set to `true`.