### PR TITLE
Update proof.computer's polkadot.json slot

### DIFF
--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -2255,8 +2255,8 @@
     },
     {
       "slotId": 275,
-      "name": "futureproof",
-      "stash": "13unkT9DyFUnzKZdLCkHBvGLuhvcHQSrRhTWhrL9gqG98CTH",
+      "name": "weatherproof",
+      "stash": "12KzKVWqYqyEXx4RpPLvbPTakfrhNgfXeTWSR65CF8ZrFHrt",
       "kusamaStash": "J3f7ULfjVbbBYvZtMvaEDiUC8odXjt2A2hGShshBFCKHazY",
       "riotHandle": [
         "@firegrass:matrix.org",


### PR DESCRIPTION
Swap out `futureproof` for `weatherproof` as it is now independent. 