### PR TITLE
Fix min rank message

### DIFF
--- a/packages/common/src/constraints/ValidityChecks.ts
+++ b/packages/common/src/constraints/ValidityChecks.ts
@@ -381,7 +381,7 @@ export const checkKusamaRank = async (
       }
 
       if (Number(res.data.rank) < Constants.KUSAMA_RANK_VALID_THRESHOLD) {
-        const invalidityReason = `${candidate.name} has a Kusama stash with lower than 25 rank in the Kusama OTV programme: ${res.data.rank}.`;
+        const invalidityReason = `${candidate.name} has a Kusama stash with lower than 100 rank in the Kusama 1KV programme: ${res.data.rank}.`;
         await setKusamaRankInvalidity(candidate, false, invalidityReason);
         return false;
       }


### PR DESCRIPTION
The message for the min Kusama rank validity check wasn't updated to reflect the change to rank 100 and it was misleading