### PR TITLE
Making docker image thinner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,23 @@
-FROM node:22-slim AS builder
-ARG MATRIX_TOKEN
-ARG PACKAGE
-ENV PACKAGE ${PACKAGE}
+FROM node:22-slim AS docs_builder
 WORKDIR /code
 
 COPY docs docs
 RUN cd docs && npm install && npm run build
+
+FROM node:22-slim
+WORKDIR /code
+ARG MATRIX_TOKEN
+ARG PACKAGE
+ENV PACKAGE ${PACKAGE}
+
+COPY --from=docs_builder /code/docs/build/ /code/docs/build/
 
 COPY . .
 
 RUN --mount=type=cache,target=/code/.yarn/cache \
     --mount=type=cache,target=/turbo_cache \
     yarn install --immutable && \
-    yarn turbo --cache-dir /turbo_cache
+    yarn turbo --cache-dir /turbo_cache && \
+    yarn workspaces focus --production
 
 CMD yarn run start:js:${PACKAGE}

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "coingecko-api-v3": "^0.0.29",
     "commander": "^12.0.0",
     "cron": "^3.1.6",
+    "date-fns": "^3.6.0",
     "eventemitter3": "^5.0.1",
     "koa": "^2.15.0",
     "koa-bodyparser": "^4.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,6 +34,7 @@ __metadata:
     commander: ^12.0.0
     concurrently: ^8.2.2
     cron: ^3.1.6
+    date-fns: ^3.6.0
     eslint: 8.42.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-prettier: 5.0.0
@@ -4176,6 +4177,13 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.21.0
   checksum: f7be01523282e9bb06c0cd2693d34f245247a29098527d4420628966a2d9aad154bd0e90a6b1cf66d37adcb769cd108cf8a7bd49d76db0fb119af5cdd13644f4
+  languageName: node
+  linkType: hard
+
+"date-fns@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "date-fns@npm:3.6.0"
+  checksum: 0daa1e9a436cf99f9f2ae9232b55e11f3dd46132bee10987164f3eebd29f245b2e066d7d7db40782627411ecf18551d8f4c9fcdf2226e48bb66545407d448ab7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
By splitting build into two stages, we'll take only docs/build into the layers.
`yarn workspaces focus --production` removes all devDependencies, which also aren't needed after build.
`date-fns` wasn't specified in deps at all, but needed at runtime. Fixed.

The result: image went from 1.26GB to 472MB