### PR TITLE
Update polkadot.json -> helixstreet name & stash

### DIFF
--- a/candidates/polkadot.json
+++ b/candidates/polkadot.json
@@ -1900,8 +1900,8 @@
     },
     {
       "slotId": 232,
-      "name": "helixstreet/2",
-      "stash": "1HMQVknF2rGz2vBegqA9jU4NhZKQtW7nZTDQykgeSm8FgPa",
+      "name": "helixstreet/3",
+      "stash": "15qiiCBRGjyKbQRLci7cM9gHWDqNDGY8LZTTksczsy4j1dKb",
       "kusamaStash": "J6K1vA6ynGo2GrotGpP5ocHKr82JFTv7NUnzJcoRfTcCn8T",
       "riotHandle": "@helixstreet.io:matrix.org",
       "skipSelfStake": true,


### PR DESCRIPTION
Reasoning: Validator helixstreet/2 achieved self-sufficiency with exceptional rapidity.