### PR TITLE
Removing JSON.stringify from errors

### DIFF
--- a/packages/common/src/ApiHandler/ApiHandler.ts
+++ b/packages/common/src/ApiHandler/ApiHandler.ts
@@ -72,10 +72,10 @@ class ApiHandler extends EventEmitter {
         logger.info(`Connected to ${this.currentEndpoint()}`, apiLabel);
         resolve();
       } catch (err) {
-        logger.warn(
-          `Connection attempt to ${this.currentEndpoint()} failed: ${JSON.stringify(err)}, trying next endpoint`,
-          apiLabel,
-        );
+        logger.warn(err, {
+          message: `Connection attempt to ${this.currentEndpoint()} failed, trying next endpoint`,
+          ...apiLabel,
+        });
         setTimeout(() => {
           this.connectionAttempt = null;
           this.connectWithRetry().then(resolve);
@@ -109,10 +109,10 @@ class ApiHandler extends EventEmitter {
       const api = await this.getApi();
       await api.rpc.system.chain();
     } catch (err) {
-      logger.warn(
-        `Healthcheck on ${this.currentEndpoint()} failed: ${JSON.stringify(err)}, trying next endpoint`,
-        apiLabel,
-      );
+      logger.warn(err, {
+        message: `Healthcheck on ${this.currentEndpoint()} failed, trying next endpoint`,
+        ...apiLabel,
+      });
       await this.nextEndpoint();
     }
   }

--- a/packages/common/src/chaindata/queries/Era.ts
+++ b/packages/common/src/chaindata/queries/Era.ts
@@ -142,7 +142,7 @@ export const getActiveEraIndex = async (
       "getActiveEraIndex",
       HandlerType.RelayHandler,
     );
-    return [0, JSON.stringify(e)];
+    return [0, String(e)];
   }
 };
 
@@ -231,7 +231,7 @@ export const findEraBlockHash = async (
       "findEraBlockHash",
       HandlerType.RelayHandler,
     );
-    return ["", JSON.stringify(e)];
+    return ["", String(e)];
   }
 };
 
@@ -308,6 +308,6 @@ export const findEraBlockNumber = async (
       "findEraBlockNumber",
       HandlerType.RelayHandler,
     );
-    return [0, JSON.stringify(e)];
+    return [0, String(e)];
   }
 };

--- a/packages/common/src/chaindata/queries/ValidatorPref.ts
+++ b/packages/common/src/chaindata/queries/ValidatorPref.ts
@@ -20,7 +20,7 @@ export const getCommission = async (
     return [prefs.commission.toNumber(), null];
   } catch (e) {
     await handleError(chaindata, e, "getCommission", HandlerType.RelayHandler);
-    return [0, JSON.stringify(e)];
+    return [0, String(e)];
   }
 };
 
@@ -114,7 +114,7 @@ export const getDenomBondedAmount = async (
       "getDenomBondedAmount",
       HandlerType.RelayHandler,
     );
-    return [0, JSON.stringify(e)];
+    return [0, String(e)];
   }
 };
 
@@ -139,7 +139,7 @@ export const getBondedAmount = async (
     return [ledger.toJSON().active, null];
   } catch (e) {
     logger.error(`Error getting bonded amount: ${e}`, chaindataLabel);
-    return [0, JSON.stringify(e)];
+    return [0, String(e)];
   }
 };
 

--- a/packages/common/src/chaindata/queries/Validators.ts
+++ b/packages/common/src/chaindata/queries/Validators.ts
@@ -42,7 +42,7 @@ export const getActiveValidatorsInPeriod = async (
       "getActiveValidatorsInPeriod",
       HandlerType.RelayHandler,
     );
-    return [[], JSON.stringify(e)];
+    return [[], String(e)];
   }
 };
 

--- a/packages/common/src/config.ts
+++ b/packages/common/src/config.ts
@@ -208,6 +208,8 @@ export const loadConfigDir = async (configDir: string) => {
 
     return mainConf;
   } catch (e) {
-    logger.error(`Error loading config: ${JSON.stringify(e)}`);
+    logger.error(e, {
+      message: "Error loading config",
+    });
   }
 };

--- a/packages/common/src/constraints/CheckCandidates.ts
+++ b/packages/common/src/constraints/CheckCandidates.ts
@@ -163,7 +163,7 @@ export const checkCandidate = async (
     }
     return valid;
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     return false;
   }
 };
@@ -196,7 +196,7 @@ export const checkAllCandidates = async (
     }
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     return false;
   }
 };

--- a/packages/common/src/constraints/ProcessCandidates.ts
+++ b/packages/common/src/constraints/ProcessCandidates.ts
@@ -11,72 +11,63 @@ export const processCandidates = async (
   constraints: OTV,
   candidates: Set<Candidate>,
 ): Promise<[Set<Candidate>, Set<{ candidate: Candidate; reason: string }>]> => {
-  try {
-    logger.info(`Processing ${candidates.size} candidates`, constraintsLabel);
+  logger.info(`Processing ${candidates.size} candidates`, constraintsLabel);
 
-    const good: Set<Candidate> = new Set();
-    const bad: Set<{ candidate: Candidate; reason: string }> = new Set();
+  const good: Set<Candidate> = new Set();
+  const bad: Set<{ candidate: Candidate; reason: string }> = new Set();
 
-    for (const candidate of candidates) {
-      if (!candidate) {
-        logger.warn(
-          `candidate is null. Skipping processing..`,
-          constraintsLabel,
-        );
-        continue;
-      }
-      const { name, stash, skipSelfStake, offlineAccumulated } = candidate;
-      /// Ensure the commission wasn't raised/
-      const [commission, err] =
-        await constraints.chaindata.getCommission(stash);
-      /// If it errors we assume that a validator removed their validator status.
-      if (err) {
-        const reason = `${name} ${err}`;
-        logger.warn(reason, constraintsLabel);
-        bad.add({ candidate, reason });
-        continue;
-      }
-
-      if (commission > constraints.commission) {
-        const reason = `${name} found commission higher than ten percent: ${commission}`;
-        logger.warn(reason, constraintsLabel);
-        bad.add({ candidate, reason });
-        continue;
-      }
-
-      if (!skipSelfStake) {
-        const [bondedAmt, err2] =
-          await constraints.chaindata.getBondedAmount(stash);
-        if (err2) {
-          const reason = `${name} ${err2}`;
-          logger.warn(reason, constraintsLabel);
-          bad.add({ candidate, reason });
-          continue;
-        }
-        if (bondedAmt < constraints.minSelfStake) {
-          const reason = `${name} has less than the minimum required amount bonded: ${bondedAmt}`;
-          logger.warn(reason, constraintsLabel);
-          bad.add({ candidate, reason });
-          continue;
-        }
-      }
-
-      // Ensure the candidate doesn't have too much offline time
-      const totalOffline = offlineAccumulated / Constants.WEEK;
-      if (totalOffline > 0.02) {
-        const reason = `${name} has been offline ${
-          offlineAccumulated / 1000 / 60
-        } minutes this week.`;
-        logger.info(reason);
-        bad.add({ candidate, reason });
-        continue;
-      }
-
-      good.add(candidate);
+  for (const candidate of candidates) {
+    if (!candidate) {
+      logger.warn(`candidate is null. Skipping processing..`, constraintsLabel);
+      continue;
     }
-    return [good, bad];
-  } catch (e) {
-    logger.error(JSON.stringify(e), constraintsLabel);
-    throw e;
+    const { name, stash, skipSelfStake, offlineAccumulated } = candidate;
+    /// Ensure the commission wasn't raised/
+    const [commission, err] = await constraints.chaindata.getCommission(stash);
+    /// If it errors we assume that a validator removed their validator status.
+    if (err) {
+      const reason = `${name} ${err}`;
+      logger.warn(reason, constraintsLabel);
+      bad.add({ candidate, reason });
+      continue;
+    }
+
+    if (commission > constraints.commission) {
+      const reason = `${name} found commission higher than ten percent: ${commission}`;
+      logger.warn(reason, constraintsLabel);
+      bad.add({ candidate, reason });
+      continue;
+    }
+
+    if (!skipSelfStake) {
+      const [bondedAmt, err2] =
+        await constraints.chaindata.getBondedAmount(stash);
+      if (err2) {
+        const reason = `${name} ${err2}`;
+        logger.warn(reason, constraintsLabel);
+        bad.add({ candidate, reason });
+        continue;
+      }
+      if (bondedAmt < constraints.minSelfStake) {
+        const reason = `${name} has less than the minimum required amount bonded: ${bondedAmt}`;
+        logger.warn(reason, constraintsLabel);
+        bad.add({ candidate, reason });
+        continue;
+      }
+    }
+
+    // Ensure the candidate doesn't have too much offline time
+    const totalOffline = offlineAccumulated / Constants.WEEK;
+    if (totalOffline > 0.02) {
+      const reason = `${name} has been offline ${
+        offlineAccumulated / 1000 / 60
+      } minutes this week.`;
+      logger.info(reason);
+      bad.add({ candidate, reason });
+      continue;
+    }
+
+    good.add(candidate);
   }
+  return [good, bad];
 };

--- a/packages/common/src/constraints/ScoreCandidates.ts
+++ b/packages/common/src/constraints/ScoreCandidates.ts
@@ -272,16 +272,17 @@ export const scoreCandidate = async (
     try {
       await setValidatorScore(candidate.stash, session, score);
     } catch (e) {
-      logger.info(`Can't set validator score....`);
-      logger.info(JSON.stringify(e));
+      logger.info(e, {
+        message: "Can't set validator score....",
+        ...constraintsLabel,
+      });
     }
     return total;
   } catch (e) {
-    logger.error(
-      `Error scoring candidate ${candidate.name}`,
-      e,
-      constraintsLabel,
-    );
+    logger.error(e, {
+      message: `Error scoring candidate ${candidate.name}`,
+      ...constraintsLabel,
+    });
     return null;
   }
 };

--- a/packages/common/src/db/index.ts
+++ b/packages/common/src/db/index.ts
@@ -41,7 +41,7 @@ export class Db {
       mongoose.connection.on("open", () => setDbConnectivity(true));
       mongoose.connection.on("disconnected", () => setDbConnectivity(false));
       mongoose.connection.on("error", (err) => {
-        logger.error(`MongoDB connection issue: ${err}`, dbLabel);
+        logger.error(err, { message: "MongoDB connection issue", ...dbLabel });
         reject(err);
       });
     });

--- a/packages/common/src/db/queries/Candidate.ts
+++ b/packages/common/src/db/queries/Candidate.ts
@@ -88,8 +88,10 @@ export const addCandidate = async (
     ).exec();
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(`Error adding candidate ${name}`, dbLabel);
+    logger.error(e, {
+      message: `Error adding candidate ${name}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -262,8 +264,10 @@ export const setCandidateIdentity = async (
     }
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(`Error setting identity for ${stash}`, dbLabel);
+    logger.error(e, {
+      message: `Error setting identity for ${stash}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -411,12 +415,11 @@ export const updateCandidateOnlineTelemetryDetails = async (
     );
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
     // Correctly reference telemetryNodeDetails.name in the logging statement
-    logger.error(
-      `Error updating online validity for ${telemetryNodeDetails.name}`,
-      dbLabel,
-    );
+    logger.error(e, {
+      message: `Error updating online validity for ${telemetryNodeDetails.name}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -442,8 +445,10 @@ export const updateCandidateOfflineTime = async (
     }
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(`Error updating offline time for ${name}`, dbLabel);
+    logger.error(e, {
+      message: `Error updating offline time for ${name}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -476,12 +481,10 @@ export const reportOnline = async (
     }
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(JSON.stringify(telemetryNodeDetails));
-    logger.error(
-      `Error reporting telemetry node online ${telemetryNodeDetails?.name}`,
-      dbLabel,
-    );
+    logger.error(e, {
+      message: `Error reporting telemetry node online ${telemetryNodeDetails?.name}; telemetryNodeDetails: ${JSON.stringify(telemetryNodeDetails)}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -508,11 +511,10 @@ export const reportOffline = async (name: string): Promise<void> => {
       }
     }
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(
-      `Error reporting candidate or telemetry node offline ${name}`,
-      dbLabel,
-    );
+    logger.error(e, {
+      message: `Error reporting candidate or telemetry node offline ${name}`,
+      ...dbLabel,
+    });
   }
 };
 

--- a/packages/common/src/db/queries/Era.ts
+++ b/packages/common/src/db/queries/Era.ts
@@ -1,5 +1,6 @@
 import { Era, EraModel } from "../models";
 import logger from "../../logger";
+import { dbLabel } from "../index";
 
 export const setLastNominatedEraIndex = async (
   index: number,
@@ -27,9 +28,10 @@ export const setLastNominatedEraIndex = async (
     ).exec();
     return true;
   } catch (e) {
-    logger.error(
-      `Error setting last nominated era index: ${JSON.stringify(e)}`,
-    );
+    logger.error(e, {
+      message: "Error setting last nominated era index",
+      ...dbLabel,
+    });
     return false;
   }
 };

--- a/packages/common/src/db/queries/EraStats.ts
+++ b/packages/common/src/db/queries/EraStats.ts
@@ -52,7 +52,10 @@ export const setEraStats = async (
     ).exec();
     return true;
   } catch (e) {
-    logger.error(`Error setting era stats: ${JSON.stringify(e)}`, dbLabel);
+    logger.error(e, {
+      message: "Error setting era stats",
+      ...dbLabel,
+    });
     return false;
   }
 };

--- a/packages/common/src/db/queries/Location.ts
+++ b/packages/common/src/db/queries/Location.ts
@@ -122,8 +122,10 @@ export const setLocation = async (
     }
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(`Error setting location`, dbLabel);
+    logger.error(e, {
+      message: "Error setting location",
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -142,10 +144,10 @@ export const cleanOldLocations = async (): Promise<boolean> => {
     await LocationModel.deleteMany({ updated: { $lt: twoDaysAgo } }).exec();
     return true;
   } catch (error) {
-    logger.info(
-      `Error cleaning old locations: ${JSON.stringify(error)}`,
-      dbLabel,
-    );
+    logger.info(error, {
+      message: "Error cleaning old locations",
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -155,10 +157,10 @@ export const cleanLocationsWithoutSlotId = async (): Promise<boolean> => {
     await LocationModel.deleteMany({ slotId: { $exists: false } }).exec();
     return true;
   } catch (error) {
-    logger.error(
-      `Error deleting locations without 'slotId': ${JSON.stringify(error)}`,
-      dbLabel,
-    );
+    logger.error(error, {
+      message: "Error deleting locations without 'slotId'",
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -190,8 +192,10 @@ export const removeIIT = async (): Promise<any> => {
   try {
     return IITModel.deleteOne({}).exec();
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(`Error deleting IIT`, dbLabel);
+    logger.error(e, {
+      message: "Error deleting IIT",
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -213,8 +217,11 @@ export const updateIITRequestCount = async (): Promise<any> => {
 
     return updateResult;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error("Error updating IIT request count", dbLabel);
+    logger.error(e, {
+      message: "Error updating IIT request count",
+      ...dbLabel,
+    });
+
     return false;
   }
 };

--- a/packages/common/src/db/queries/Nomination.ts
+++ b/packages/common/src/db/queries/Nomination.ts
@@ -1,4 +1,6 @@
 import { Nomination, NominationModel } from "../models";
+import { logger } from "../../index";
+import { dbLabel } from "../index";
 
 export const setNomination = async (
   address: string,
@@ -38,7 +40,7 @@ export const setNomination = async (
     }).exec();
     return true;
   } catch (e) {
-    console.error(`Error setting nomination: ${JSON.stringify(e)}`);
+    logger.error(e, { message: "Error setting nomination", ...dbLabel });
     return false;
   }
 };

--- a/packages/common/src/db/queries/Nominator.ts
+++ b/packages/common/src/db/queries/Nominator.ts
@@ -1,5 +1,6 @@
 import { CandidateModel, Nominator, NominatorModel } from "../models";
 import logger from "../../logger";
+import { dbLabel } from "../index";
 import { getCandidateByStash } from "./Candidate";
 
 /**
@@ -67,8 +68,11 @@ export const addNominator = async (nominator: Nominator): Promise<boolean> => {
     );
     return true;
   } catch (e) {
-    logger.info(JSON.stringify(e));
-    logger.error(`Could not add nominator: ${JSON.stringify(nominator)}`);
+    logger.error(e, {
+      message: `Could not add nominator: ${JSON.stringify(nominator)}`,
+      ...dbLabel,
+    });
+
     return false;
   }
 };
@@ -157,7 +161,7 @@ export const getCurrentTargets = async (
       return [];
     }
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e, dbLabel);
     return [];
   }
 };

--- a/packages/common/src/db/queries/NominatorStake.ts
+++ b/packages/common/src/db/queries/NominatorStake.ts
@@ -52,7 +52,10 @@ export const setNominatorStake = async (
     ).exec();
     return true;
   } catch (e) {
-    console.error(`Error setting nominator stake: ${JSON.stringify(e)}`);
+    logger.error(e, {
+      message: "Error setting nominator stake",
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -96,11 +99,11 @@ export const cleanOldNominatorStakes = async (): Promise<boolean> => {
       updated: { $lt: twoDaysAgo },
     }).exec();
     return true;
-  } catch (error) {
-    logger.info(
-      `Error cleaning old nominator stakes: ${JSON.stringify(error)}`,
-      dbLabel,
-    );
+  } catch (e) {
+    logger.info(e, {
+      message: "Error cleaning old nominator stakes",
+      ...dbLabel,
+    });
     return false;
   }
 };

--- a/packages/common/src/db/queries/TelemetryNode.ts
+++ b/packages/common/src/db/queries/TelemetryNode.ts
@@ -17,10 +17,9 @@ export const deleteTelemetryNode = async (name: string): Promise<void> => {
   try {
     await TelemetryNodeModel.deleteOne({ name });
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    const m = `Error deleting telemetry node ${name}`;
-    logger.error(m, dbLabel);
-    throw new Error(m);
+    throw new Error(
+      `Error deleting telemetry node ${name}: ${e.stack ?? String(e)}`,
+    );
   }
 };
 
@@ -41,11 +40,10 @@ export const addNewTelemetryNode = async (
     await telemetryNode.save();
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(
-      `Error adding new telemetry node ${telemetryNodeDetails.name}`,
-      dbLabel,
-    );
+    logger.error(e, {
+      message: `Error adding new telemetry node ${telemetryNodeDetails.name}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -74,11 +72,10 @@ export const updateTelemetryNodeOfflineTime = async (
     }
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(
-      `Error updating offline time for telemetry node ${telemetryNodeDetails.name}`,
-      dbLabel,
-    );
+    logger.error(e, {
+      message: `Error updating offline time for telemetry node ${telemetryNodeDetails.name}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -106,11 +103,10 @@ export const updateExistingTelemetryNode = async (
     await updateTelemetryNodeOfflineTime(telemetryNodeDetails);
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(
-      `Error updating existing telemetry node ${telemetryNodeDetails.name}`,
-      dbLabel,
-    );
+    logger.error(e, {
+      message: `Error updating existing telemetry node ${telemetryNodeDetails.name}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -134,11 +130,10 @@ export const reportTelemetryNodeOnline = async (
     );
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(
-      `Error reporting telemetry node online ${telemetryNodeDetails.name}`,
-      dbLabel,
-    );
+    logger.error(e, {
+      message: `Error reporting telemetry node online ${telemetryNodeDetails.name}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -202,8 +197,10 @@ export const reportTelemetryNodeOffline = async (
     }
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(`Error reporting telemetry node offline ${name}`, dbLabel);
+    logger.error(e, {
+      message: `Error reporting telemetry node offline ${name}`,
+      ...dbLabel,
+    });
     return false;
   }
 };
@@ -222,8 +219,10 @@ export const clearTelemetryNodeNodeRefsFrom = async (
     );
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(`Error clearing telemetry node nodeRefs ${name}`, dbLabel);
+    logger.error(e, {
+      message: `Error clearing telemetry node nodeRefs ${name}`,
+      ...dbLabel,
+    });
     return false;
   }
 };

--- a/packages/common/src/db/queries/ValidatorScore.ts
+++ b/packages/common/src/db/queries/ValidatorScore.ts
@@ -1,5 +1,7 @@
 import { ValidatorScore, ValidatorScoreModel } from "../models";
 import { TWO_DAYS_IN_MS } from "../../constants";
+import logger from "../../logger";
+import { dbLabel } from "../index";
 
 export const setValidatorScore = async (
   address: string,
@@ -91,7 +93,10 @@ export const setValidatorScore = async (
     ).exec();
     return true;
   } catch (e) {
-    console.error(`Error setting validator score: ${JSON.stringify(e)}`);
+    logger.error(e, {
+      message: "Error setting validator score",
+      ...dbLabel,
+    });
     return false;
   }
 };

--- a/packages/common/src/db/queries/ValidatorScoreMetadata.ts
+++ b/packages/common/src/db/queries/ValidatorScoreMetadata.ts
@@ -86,7 +86,7 @@ export const setValidatorScoreMetadata = async (
         await validatorScoreMetadata.save();
         return true;
       } catch (e) {
-        logger.error(JSON.stringify(e));
+        logger.error(e);
         return false;
       }
     }
@@ -131,7 +131,7 @@ export const setValidatorScoreMetadata = async (
     ).exec();
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     return false;
   }
 };

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -29,8 +29,7 @@ const loadLoggerConfig = (): ConfigSchema["logger"] => {
 
     return mainConf.logger;
   } catch (e) {
-    console.log(`Error loading config: ${JSON.stringify(e)}`);
-    // logger.error(`Error loading config: ${JSON.stringify(e)}`);
+    console.log(`Error loading config: ${e.stack ?? String(e)}`);
   }
 };
 

--- a/packages/common/src/matrix.ts
+++ b/packages/common/src/matrix.ts
@@ -23,7 +23,7 @@ export default class MatrixBot {
         userId,
       });
     } catch (e) {
-      logger.error(JSON.stringify(e));
+      logger.error(e);
       logger.error("MatrixBot failed to start", label);
     }
   }

--- a/packages/common/src/nominator/NominatorTx.ts
+++ b/packages/common/src/nominator/NominatorTx.ts
@@ -80,13 +80,13 @@ export const sendProxyDelayTx = async (
 
     return true;
   } catch (e) {
-    logger.error(
-      `{Nominator::nominate} there was an error sending the tx`,
-      nominatorLabel,
-    );
-    logger.error(JSON.stringify(e), nominatorLabel);
+    logger.error(e, {
+      message: "{Nominator::nominate} there was an error sending the tx",
+      ...nominatorLabel,
+    });
+
     await nominator.updateNominatorStatus({
-      status: `Proxy Delay Error: ${JSON.stringify(e)}`,
+      status: `Proxy Delay Error: ${e?.message ?? String(e)}`,
       updated: Date.now(),
     });
     return false;
@@ -186,13 +186,13 @@ export const sendProxyTx = async (
     if (bot) await bot?.sendMessage(nominateMsg);
     return true;
   } catch (e) {
-    logger.error(
-      `{Nominator::nominate} there was an error sending the tx`,
-      nominatorLabel,
-    );
-    logger.error(JSON.stringify(e), nominatorLabel);
+    logger.error(e, {
+      message: `{Nominator::nominate} there was an error sending the tx`,
+      ...nominatorLabel,
+    });
+
     await nominator.updateNominatorStatus({
-      status: `Proxy Error: ${JSON.stringify(e)}`,
+      status: `Proxy Error: ${String(e)}`,
       updated: Date.now(),
     });
     return false;

--- a/packages/common/src/nominator/nominator.ts
+++ b/packages/common/src/nominator/nominator.ts
@@ -215,11 +215,11 @@ export default class Nominator extends EventEmitter {
         return this.bondedAddress;
       }
     } catch (e) {
-      logger.error(
-        `Error getting stash for ${this.bondedAddress}: ${e}`,
-        nominatorLabel,
-      );
-      logger.error(JSON.stringify(e), nominatorLabel);
+      logger.error(e, {
+        message: `Error getting stash for ${this.bondedAddress}`,
+        ...nominatorLabel,
+      });
+
       return this.bondedAddress;
     }
   }
@@ -240,11 +240,10 @@ export default class Nominator extends EventEmitter {
         return "";
       }
     } catch (e) {
-      logger.error(
-        `Error getting payee for ${this.bondedAddress}: ${e}`,
-        nominatorLabel,
-      );
-      logger.error(JSON.stringify(e), nominatorLabel);
+      logger.error(e, {
+        message: `Error getting payee for ${this.bondedAddress}`,
+        ...nominatorLabel,
+      });
       return "";
     }
   }
@@ -275,10 +274,13 @@ export default class Nominator extends EventEmitter {
 
       return true;
     } catch (e) {
-      logger.error(`Error sending tx: `, nominatorLabel);
-      logger.error(JSON.stringify(e), nominatorLabel);
+      logger.error(e, {
+        message: "Error sending tx",
+        ...nominatorLabel,
+      });
+
       await this.updateNominatorStatus({
-        status: `[signAndSend] Error signing and sending tx: ${JSON.stringify(e)}`,
+        status: `[signAndSend] Error signing and sending tx: ${String(e)}`,
         updated: Date.now(),
         stale: false,
       });
@@ -601,8 +603,12 @@ export default class Nominator extends EventEmitter {
       await this.updateNominatorStatus(nominatorStatus);
       return [didSend, finalizedBlockHash || null]; // Change to return undefined
     } catch (e) {
-      logger.error(`Error sending tx: ${JSON.stringify(e)}`, nominatorLabel);
-      return [false, JSON.stringify(e)];
+      logger.error(e, {
+        message: "Error sending tx",
+        ...nominatorLabel,
+      });
+
+      return [false, String(e)];
     }
   };
 }

--- a/packages/common/src/scorekeeper/Nominating.ts
+++ b/packages/common/src/scorekeeper/Nominating.ts
@@ -181,10 +181,7 @@ export const doNominations = async (
 
     return counter;
   } catch (e) {
-    logger.error(
-      `Error in doNominations: ${JSON.stringify(e)}`,
-      scorekeeperLabel,
-    );
+    logger.error(e, { message: "Error in doNominations", ...scorekeeperLabel });
     return null;
   }
 };

--- a/packages/common/src/scorekeeper/jobs/JobConfigs.ts
+++ b/packages/common/src/scorekeeper/jobs/JobConfigs.ts
@@ -252,8 +252,10 @@ export const getJobConfigs = (
       staleNominationJobConfig,
     ];
   } catch (e) {
-    logger.error(`Error getting job configs:`, jobsLabel);
-    logger.error(JSON.stringify(e));
+    logger.error(e, {
+      message: "Error getting job configs",
+      ...jobsLabel,
+    });
     return [];
   }
 };

--- a/packages/common/src/scorekeeper/jobs/JobFactory.ts
+++ b/packages/common/src/scorekeeper/jobs/JobFactory.ts
@@ -93,7 +93,6 @@ export class JobFactory {
       return jobs;
     } catch (e) {
       logger.error(`Error making jobs: ${e}`, jobsLabel);
-      logger.error(JSON.stringify(e), jobsLabel);
       return [];
     }
   };

--- a/packages/common/src/scorekeeper/jobs/JobRunner.ts
+++ b/packages/common/src/scorekeeper/jobs/JobRunner.ts
@@ -30,8 +30,11 @@ export const startMonolithJobs = async (
     }
     return jobs;
   } catch (e) {
-    logger.error(JSON.stringify(e), scorekeeperLabel);
-    logger.error("Error starting monolith jobs", scorekeeperLabel);
+    logger.error(e, {
+      message: "Error starting monolith jobs",
+      ...scorekeeperLabel,
+    });
+
     return [];
   }
 };

--- a/packages/common/src/scorekeeper/jobs/cron/SetupCronJob.ts
+++ b/packages/common/src/scorekeeper/jobs/cron/SetupCronJob.ts
@@ -59,7 +59,7 @@ export const setupCronJob = async (
         name: name,
         runCount: jobRunCount,
         updated: Date.now(),
-        error: JSON.stringify(e),
+        error: String(e),
         executedAt,
       };
 

--- a/packages/common/src/scorekeeper/jobs/specificJobs/ConstraintsJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/ConstraintsJob.ts
@@ -70,7 +70,7 @@ export const validityJob = async (
       status: "errored",
       name: JobNames.Validity,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
     jobStatusEmitter.emit("jobErrored", errorStatus);
     return false;
@@ -129,7 +129,7 @@ export const scoreJob = async (
       status: "errored",
       name: JobNames.Score,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
     jobStatusEmitter.emit("jobErrored", errorStatus);
     return false;

--- a/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/EraPointsJob.ts
@@ -44,10 +44,10 @@ export const individualEraPointsJob = async (
     }
     return true;
   } catch (e) {
-    logger.error(
-      `Error running individual era points job: ${JSON.stringify(e)}`,
-      erapointsLabel,
-    );
+    logger.error(e, {
+      message: "Error running individual era points job",
+      ...erapointsLabel,
+    });
     return false;
   }
 };
@@ -93,7 +93,7 @@ export const eraPointsJob = async (
       status: "errored",
       name: JobNames.EraPoints,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
     jobStatusEmitter.emit("jobErrored", errorStatus);
     return false;

--- a/packages/common/src/scorekeeper/jobs/specificJobs/EraStatsJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/EraStatsJob.ts
@@ -127,7 +127,7 @@ export const eraStatsJob = async (
       status: "errored",
       name: JobNames.EraStats,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
     jobStatusEmitter.emit("jobErrored", errorStatus);
     return false;

--- a/packages/common/src/scorekeeper/jobs/specificJobs/ExecutionJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/ExecutionJob.ts
@@ -252,8 +252,9 @@ export const executionJob = async (
     });
     return true;
   } catch (e) {
-    logger.error(`Error executing executionJob:`);
-    logger.error(JSON.stringify(e));
+    logger.error(e, {
+      message: "Error executing executionJob",
+    });
     return false;
   }
 };

--- a/packages/common/src/scorekeeper/jobs/specificJobs/InclusionJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/InclusionJob.ts
@@ -80,7 +80,7 @@ export const inclusionJob = async (
       status: "errored",
       name: JobNames.Inclusion,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
 
     jobStatusEmitter.emit("jobErrored", errorStatus);

--- a/packages/common/src/scorekeeper/jobs/specificJobs/LocationStatsJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/LocationStatsJob.ts
@@ -320,7 +320,7 @@ export const locationStatsJob = async (metadata: JobRunnerMetadata) => {
       status: "errored",
       name: JobNames.LocationStats,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
 
     jobStatusEmitter.emit("jobErrored", errorStatus);

--- a/packages/common/src/scorekeeper/jobs/specificJobs/MainScorekeeperJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/MainScorekeeperJob.ts
@@ -28,7 +28,7 @@ export const mainScorekeeperJob = async (
       status: "errored",
       name: JobNames.MainScorekeeper,
       updated: Date.now(),
-      error: JSON.stringify(err),
+      error: String(err),
     };
 
     jobStatusEmitter.emit("jobErrored", errorStatus);

--- a/packages/common/src/scorekeeper/jobs/specificJobs/NominatorJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/NominatorJob.ts
@@ -78,7 +78,7 @@ export const nominatorJob = async (
       status: "errored",
       name: JobNames.Nominator,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
 
     jobStatusEmitter.emit("jobErrored", errorStatus);

--- a/packages/common/src/scorekeeper/jobs/specificJobs/ReleaseMonitorJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/ReleaseMonitorJob.ts
@@ -79,7 +79,7 @@ export const getLatestTaggedRelease = async (releaseTagFormat: string) => {
       status: "errored",
       name: JobNames.Monitor,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
 
     jobStatusEmitter.emit("jobErrored", errorStatus);

--- a/packages/common/src/scorekeeper/jobs/specificJobs/SessionKeyJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/SessionKeyJob.ts
@@ -59,7 +59,7 @@ export const sessionKeyJob = async (metadata: JobRunnerMetadata) => {
       status: "errored",
       name: JobNames.SessionKey,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
 
     jobStatusEmitter.emit("jobErrored", errorStatus);

--- a/packages/common/src/scorekeeper/jobs/specificJobs/StaleNomination.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/StaleNomination.ts
@@ -43,8 +43,10 @@ export const staleNominationJob = async (
     }
     return true;
   } catch (e) {
-    logger.error(`Error in staleNominationJob:`, cronLabel);
-    logger.error(JSON.stringify(e), cronLabel);
+    logger.error(e, {
+      message: "Error in staleNominationJob",
+      ...cronLabel,
+    });
     return false;
   }
 };

--- a/packages/common/src/scorekeeper/jobs/specificJobs/ValidatorPrefJob.ts
+++ b/packages/common/src/scorekeeper/jobs/specificJobs/ValidatorPrefJob.ts
@@ -108,7 +108,7 @@ export const validatorPrefJob = async (
       status: "errored",
       name: JobNames.ValidatorPref,
       updated: Date.now(),
-      error: JSON.stringify(e),
+      error: String(e),
     };
 
     jobStatusEmitter.emit("jobErrored", errorStatus);

--- a/packages/common/src/scorekeeper/scorekeeper.ts
+++ b/packages/common/src/scorekeeper/scorekeeper.ts
@@ -63,6 +63,7 @@ export default class ScoreKeeper {
     registerAPIHandler(this.chaindata, this.bot);
     registerEventEmitterHandler(this);
   }
+
   public getJobsStatusAsJson() {
     const statuses: Record<string, JobStatus> = {};
     for (const job of this._jobs) {
@@ -151,11 +152,10 @@ export default class ScoreKeeper {
         try {
           await queries.addNominator(nominator);
         } catch (e) {
-          logger.error(JSON.stringify(e), scorekeeperLabel);
-          logger.error(
-            `Scorekeeper add nominator: ${JSON.stringify(nominator)} failed`,
-            scorekeeperLabel,
-          );
+          logger.error(e, {
+            message: `Scorekeeper add nominator: ${JSON.stringify(nominator)} failed`,
+            ...scorekeeperLabel,
+          });
         }
 
         group.push(nom);
@@ -291,7 +291,7 @@ export default class ScoreKeeper {
       this.isStarted = true;
       return true;
     } catch (e) {
-      logger.error(JSON.stringify(e), scorekeeperLabel);
+      logger.error(e, scorekeeperLabel);
       return false;
     }
   }

--- a/packages/common/src/utils/CleanDB.ts
+++ b/packages/common/src/utils/CleanDB.ts
@@ -45,8 +45,8 @@ export const cleanDB = async (scorekeeper?: ScoreKeeper): Promise<boolean> => {
     }
 
     return true;
-  } catch (error) {
-    logger.error(`Error cleaning DB: ${JSON.stringify(error)}`, dbLabel);
+  } catch (e) {
+    logger.error(e, { message: "Error cleaning DB", ...dbLabel });
     return false;
   }
 };

--- a/packages/common/src/utils/Location.ts
+++ b/packages/common/src/utils/Location.ts
@@ -94,9 +94,10 @@ export const nodeDetailsFromTelemetryMessage = (
       networkId: networkId,
     };
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(JSON.stringify(payload));
-    logger.error(`Error parsing telemetry message`, { label: "Telemetry" });
+    logger.error(e, {
+      message: `Error parsing telemetry message: ${JSON.stringify(payload)}`,
+      label: "Telemetry",
+    });
     return null;
   }
 };
@@ -171,8 +172,7 @@ export const initIIT = async (ipinfoToken: string): Promise<boolean> => {
     }
     return true;
   } catch (e) {
-    logger.error(JSON.stringify(e));
-    logger.error(`Error initializing IIT`, { label: "Telemetry" });
+    logger.error(e, { label: "Telemetry", message: `Error initializing IIT` });
     return false;
   }
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,7 +28,7 @@ const catchAndQuit = async (fn: any) => {
   try {
     await fn;
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     process.exit(1);
   }
 };
@@ -58,7 +58,7 @@ export const createDB = async (config) => {
     await Db.create(config.db.mongo.uri);
     logger.info(`Connected to ${config.db.mongo.uri}`, winstonLabel);
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     process.exit(1);
   }
 };
@@ -79,7 +79,7 @@ export const createServer = async (
       );
     }
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     process.exit(1);
   }
 };
@@ -92,7 +92,7 @@ export const createTelemetry = async (config) => {
     await telemetry.start();
     logger.info(`Telemetry client started.`, winstonLabel);
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     process.exit(1);
   }
 };
@@ -112,7 +112,7 @@ export const createMatrixBot = async (config) => {
     logger.info(`matrix client started.`, winstonLabel);
     return maybeBot;
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     process.exit(1);
   }
 };
@@ -124,7 +124,7 @@ export const clean = async (scorekeeper: ScoreKeeper) => {
 
     logger.info(`Cleaning finished`, winstonLabel);
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     process.exit(1);
   }
 };
@@ -176,7 +176,7 @@ export const addCleanCandidates = async (config: Config.ConfigSchema) => {
     // Remove any candidate in the db that doesn't have a stash or slotId
     await queries.deleteCandidatesWithMissingFields();
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     process.exit(1);
   }
 };
@@ -186,7 +186,7 @@ export const setChainMetadata = async (config) => {
     logger.info(`Setting chain metadata`, winstonLabel);
     await queries.setChainMetadata(config.global.networkPrefix);
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     process.exit(1);
   }
 };
@@ -205,7 +205,7 @@ export const initScorekeeper = async (
     }
     return scorekeeper;
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     process.exit(1);
   }
 };
@@ -219,6 +219,7 @@ async function setInitialLatestBlock() {
 
 const start = async (cmd: { config: string }) => {
   try {
+    throw new Error("sdfsdfs");
     const config = await Config.loadConfigDir(cmd.config);
     setupMetrics(config);
 
@@ -262,8 +263,10 @@ const start = async (cmd: { config: string }) => {
     // Start the scorekeeper
     await scorekeeper.begin();
   } catch (e) {
-    logger.error(`Error starting backend services`, winstonLabel);
-    logger.error(JSON.stringify(e));
+    logger.error(e, {
+      message: "Error starting backend services",
+      ...winstonLabel,
+    });
     process.exit(1);
   }
 };

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -74,7 +74,7 @@ export default class Server {
       );
       return true;
     } catch (e) {
-      logger.error(JSON.stringify(e), { label: "Gateway" });
+      logger.error(e, { label: "Gateway" });
       return false;
     }
   }

--- a/packages/telemetry/src/Telemetry/TelemetryMessage.ts
+++ b/packages/telemetry/src/Telemetry/TelemetryMessage.ts
@@ -110,7 +110,7 @@ export const handleAddedNode = async (
       );
     }
   } catch (e) {
-    logger.error(JSON.stringify(e));
+    logger.error(e);
     logger.error(JSON.stringify(payload));
   }
 };

--- a/packages/telemetry/src/Telemetry/TelemetryWS.ts
+++ b/packages/telemetry/src/Telemetry/TelemetryWS.ts
@@ -46,8 +46,10 @@ export const registerTelemetryWs = async (telemetryClient: TelemetryClient) => {
       }
     });
   } catch (e) {
-    logger.error(`Telemetry error registering socket`, { label: "Telemetry" });
-    logger.error(JSON.stringify(e), { label: "Telemetry" });
+    logger.error(e, {
+      message: "Telemetry error registering socket",
+      label: "Telemetry",
+    });
   }
 };
 
@@ -59,7 +61,9 @@ export const subscribeWs = async (socket: WebSocket, chain: string) => {
     // socket.send(`ping:${chain}`);
     socket.send(`subscribe:${chain}`);
   } catch (e) {
-    logger.error(`Telemetry error subscribing socket`, { label: "Telemetry" });
-    logger.error(JSON.stringify(e), { label: "Telemetry" });
+    logger.error(e, {
+      message: "Telemetry error subscribing socket",
+      label: "Telemetry",
+    });
   }
 };


### PR DESCRIPTION
JSON.stringify() of an Error object just returns "{}", which leads to logging empty messages.
Also, I've joined consequent logging to improve search in logs. Plus, I've removed some of the double-logging: if the error is logged, it shouldn't be thrown and vise-versa